### PR TITLE
pdb.rs: Fix Table RowGroup parsing

### DIFF
--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -399,12 +399,12 @@ impl Page {
         page_data: &'a [u8],
         page_size: u32,
     ) -> impl Iterator<Item = RowGroup> + 'a {
-        let row_groups_offset = usize::try_from(page_size).unwrap() - 2;
+        let row_groups_offset = usize::try_from(page_size).unwrap();
         self.row_group_counts()
             .map(usize::try_from)
             .map(Result::unwrap)
             .scan(row_groups_offset, |offset, num_rows_in_group| {
-                *offset -= num_rows_in_group * 2 + 2;
+                *offset -= num_rows_in_group * 2 + 4;
                 Some((*offset, num_rows_in_group))
             })
             .map(|(offset, num_rows_in_group)| {


### PR DESCRIPTION
The reference documentation contains an error which caused the
parsing to shift. This resulted in the effect that page_flags
and RowGroups could be parsed incorrectly.

see https://github.com/Deep-Symmetry/crate-digger/pull/23