### PR TITLE
pdb.rs: implement proper PageIndex iteration

### DIFF
--- a/src/bin/rekordcrate-pdb.rs
+++ b/src/bin/rekordcrate-pdb.rs
@@ -17,7 +17,7 @@ fn main() {
 
     for (i, table) in header.tables.iter().enumerate() {
         println!("Table {}: {:?}", i, table.page_type);
-        for page_index in table.page_indices() {
+        for page_index in table.page_indices(&header, &data) {
             let (_, page) = header
                 .page(&data, &page_index)
                 .expect("failed to parse page");

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -95,6 +95,52 @@ impl PageIndex {
     }
 }
 
+struct PageIndexIterator<'a> {
+    current_page_index: Option<PageIndex>,
+    table: &'a Table,
+    header: &'a Header,
+    data: &'a [u8],
+}
+
+impl<'a> PageIndexIterator<'a> {
+    pub fn new(table: &'a Table, header: &'a Header, data: &'a [u8]) -> Self {
+        Self {
+            current_page_index: Some(table.first_page.clone()),
+            table,
+            header,
+            data,
+        }
+    }
+}
+
+impl<'a> Iterator for PageIndexIterator<'a> {
+    type Item = PageIndex;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let current_page_index = self.current_page_index.clone()?;
+
+        if current_page_index == self.table.last_page {
+            self.current_page_index = None;
+        } else {
+            let next_page = self.header.page(self.data, &current_page_index).ok()?.1;
+            let next_page_index = next_page.next_page;
+            self.current_page_index = Some(
+                self.header
+                    .page(self.data, &next_page_index)
+                    .ok()?
+                    .1
+                    .page_index,
+            );
+        }
+
+        Some(current_page_index)
+    }
+}
+
+// TODO check if this makes sense, when new pages are added, this might not be
+// true
+impl std::iter::FusedIterator for PageIndexIterator<'_> {}
+
 /// Tables are linked lists of pages containing rows of a single type, which are organized
 /// into groups.
 #[derive(Debug)]
@@ -133,12 +179,12 @@ impl Table {
     }
 
     /// An iterator that yields all page indices belonging to this table.
-    pub fn page_indices(&self) -> impl Iterator<Item = PageIndex> {
-        let PageIndex(first_page_index) = self.first_page;
-        let PageIndex(last_page_index) = self.last_page;
-        (first_page_index..=last_page_index)
-            .into_iter()
-            .map(PageIndex)
+    pub fn page_indices<'a>(
+        &'a self,
+        header: &'a Header,
+        data: &'a [u8],
+    ) -> impl Iterator<Item = PageIndex> + 'a {
+        PageIndexIterator::new(self, header, data)
     }
 }
 

--- a/tests/tests_pdb.rs.in
+++ b/tests/tests_pdb.rs.in
@@ -8,7 +8,7 @@ fn pdb_{name}() {{
 
     for (i, table) in header.tables.iter().enumerate() {{
         println!("Table {{}}: {{:?}}", i, table.page_type);
-        for page_index in table.page_indices() {{
+        for page_index in table.page_indices(&header, data) {{
             let (_, page) = header
                 .page(data, &page_index)
                 .expect("failed to parse page");


### PR DESCRIPTION
The previous code worked under the assumption that a tables pages
had monotonic indicies from the first page to the last page. In
reality, pages are organized as linked lists which don't seem
to have any ordering constraints. closes #23

I'm not super familiar how to work with lifetimes properly so feel free to use this as a template for your own implementation.