### PR TITLE
pdb.rs: fix `DeviceSQLString::parse_long_utf16le` and `DeviceSQLString::parse_long_ascii`

### DIFF
--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -512,7 +512,8 @@ impl DeviceSQLString {
         let (input, length) = nom::number::complete::le_u16(input)?;
         let (input, _) = nom::bytes::complete::tag(b"\x00")(input)?;
 
-        // sanity check
+        // The length is in bytes, UTF-16 code points are always 2 bytes wide,
+        // so a valid length must be even.
         debug_assert_eq!(length % 2, 0);
 
         let str_length = usize::from(length - 4) / 2;

--- a/src/pdb.rs
+++ b/src/pdb.rs
@@ -512,13 +512,11 @@ impl DeviceSQLString {
         let (input, length) = nom::number::complete::le_u16(input)?;
         let (input, _) = nom::bytes::complete::tag(b"\x00")(input)?;
 
-        // TODO: Ensure that length is always even
-        //assert_eq!(length % 2, 0);
-        // Don't include the trailing two nullbytes in the string.
-        let str_length = usize::from(length) / 2 - 1;
+        // sanity check
+        debug_assert_eq!(length % 2, 0);
 
+        let str_length = usize::from(length - 4) / 2;
         let (input, data) = nom::multi::count(nom::number::complete::le_u16, str_length)(input)?;
-        let (input, _) = nom::bytes::complete::tag(b"\x00\x00")(input)?;
 
         String::from_utf16(&data).map_or_else(
             |_| Err(nom_input_error_with_kind(input, ErrorKind::Char)),


### PR DESCRIPTION
previous code relied on kaitai docs that theorized the presence of
two nulls at the end of these strings. The kaitai parser definition
does not check this so the theory has never been proven in practice.
Its more likely that the string just ends without any trailing null
bytes and there is likely garbage which must not be interpreted.

This theory has yet to be confirmed and it goes against the 
kaitai struct definition commonly seen as truth, so take this
PR with a grain of salt. 