### PR TITLE
anlz: Use `binrw` instead of `nom` to parse `ANLZ*.DAT` files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "modular-bitfield"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
+dependencies = [
+ "modular-bitfield-impl",
+ "static_assertions",
+]
+
+[[package]]
+name = "modular-bitfield-impl"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,8 +110,15 @@ version = "0.1.1"
 dependencies = [
  "binrw",
  "glob",
+ "modular-bitfield",
  "nom",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".*"]
 [dependencies]
 nom = "7"
 binrw = "0.8"
+modular-bitfield = "0.11"
 
 [build-dependencies]
 glob = "0.3"

--- a/src/anlz.rs
+++ b/src/anlz.rs
@@ -94,6 +94,9 @@ pub enum ContentKind {
     #[brw(magic = b"PSSI")]
     SongStructure,
     /// Unknown Kind.
+    ///
+    /// This allows handling files that contain unknown section types and allows to access later
+    /// sections in the file that have a known type instead of failing to parse the whole file.
     Unknown([u8; 4]),
 }
 
@@ -437,6 +440,8 @@ pub enum Mood {
     #[brw(magic = 3u16)]
     Low,
     /// Unknown value.
+    ///
+    /// TODO: Remove this once https://github.com/Holzhaus/rekordcrate/issues/13 has been fixed.
     Unknown(u16),
 }
 
@@ -472,6 +477,8 @@ pub enum Bank {
     #[brw(magic = 8u8)]
     Club2,
     /// Unknown value.
+    ///
+    /// TODO: Remove this once https://github.com/Holzhaus/rekordcrate/issues/13 has been fixed.
     Unknown(u8),
 }
 
@@ -581,6 +588,9 @@ pub enum Content {
     #[brw(pre_assert(header.kind == ContentKind::SongStructure))]
     SongStructure(SongStructure),
     /// Unknown content.
+    ///
+    /// This allows handling files that contain unknown section types and allows to access later
+    /// sections in the file that have a known type instead of failing to parse the whole file.
     #[brw(pre_assert(matches!(header.kind, ContentKind::Unknown(_))))]
     Unknown(#[br(args(header.clone()))] Unknown),
 }

--- a/src/anlz.rs
+++ b/src/anlz.rs
@@ -30,7 +30,7 @@ use crate::util::ColorIndex;
 use binrw::{
     binread,
     io::{Read, Seek},
-    BinRead, BinResult, ReadOptions,
+    BinRead, BinResult, NullWideString, ReadOptions,
 };
 use modular_bitfield::prelude::*;
 
@@ -264,8 +264,8 @@ pub struct ExtendedCue {
     /// Length of the comment string in bytes.
     pub len_comment: u32,
     /// An UTF-16BE encoded string, followed by a trailing  `0x0000`.
-    #[br(count = len_comment)]
-    pub comment: Vec<u8>,
+    #[br(assert((comment.len() as u32 + 1) * 2 == len_comment))]
+    pub comment: NullWideString,
     /// Rekordbox hotcue color index.
     ///
     /// | Value  | Color                       |
@@ -642,9 +642,10 @@ pub struct ExtendedCueList {
 pub struct Path {
     /// Length of the path field in bytes.
     len_path: u32,
-    #[br(assert(len_path == header.content_size()), count = len_path)]
+    #[br(assert(len_path == header.content_size()))]
     /// Path of the audio file.
-    pub path: Vec<u8>,
+    #[br(assert((path.len() as u32 + 1) * 2 == len_path))]
+    pub path: NullWideString,
 }
 
 /// Seek information for variable bitrate files (probably).

--- a/src/bin/rekordcrate-anlz.rs
+++ b/src/bin/rekordcrate-anlz.rs
@@ -6,14 +6,12 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use binrw::BinRead;
 use rekordcrate::anlz::ANLZ;
 
 fn main() {
     let path = std::env::args().nth(1).expect("no path given");
-    let data = std::fs::read(&path).expect("failed to read file");
-    let (input, anlz) = ANLZ::parse(&data).expect("failed to parse header");
-    println!("File Header: {:#?}", anlz);
-    for (i, section) in anlz.sections(input).enumerate() {
-        println!("#{}: {:#?}", i, section);
-    }
+    let mut reader = std::fs::File::open(&path).expect("failed to open file");
+    let anlz = ANLZ::read(&mut reader).expect("failed to parse setting file");
+    println!("{:#?}", anlz);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@
 
 //! Common types used in multiple modules.
 
-use binrw::binread;
+use binrw::binrw;
 use nom::error::{ErrorKind, ParseError};
 use nom::Err;
 use nom::IResult;
@@ -21,34 +21,34 @@ pub fn nom_input_error_with_kind(input: &[u8], kind: ErrorKind) -> Err<nom::erro
 
 /// Indexed Color identifiers used for memory cues and tracks.
 #[derive(Debug, PartialEq)]
-#[binread]
+#[binrw]
 pub enum ColorIndex {
     /// No color.
-    #[br(magic = 0u8)]
+    #[brw(magic = 0u8)]
     None,
     /// Pink color.
-    #[br(magic = 1u8)]
+    #[brw(magic = 1u8)]
     Pink,
     /// Red color.
-    #[br(magic = 2u8)]
+    #[brw(magic = 2u8)]
     Red,
     /// Orange color.
-    #[br(magic = 3u8)]
+    #[brw(magic = 3u8)]
     Orange,
     /// Yellow color.
-    #[br(magic = 4u8)]
+    #[brw(magic = 4u8)]
     Yellow,
     /// Green color.
-    #[br(magic = 5u8)]
+    #[brw(magic = 5u8)]
     Green,
     /// Aqua color.
-    #[br(magic = 6u8)]
+    #[brw(magic = 6u8)]
     Aqua,
     /// Blue color.
-    #[br(magic = 7u8)]
+    #[brw(magic = 7u8)]
     Blue,
     /// Purple color.
-    #[br(magic = 8u8)]
+    #[brw(magic = 8u8)]
     Purple,
     /// Unknown color.
     Unknown(u16),

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,6 +8,7 @@
 
 //! Common types used in multiple modules.
 
+use binrw::binread;
 use nom::error::{ErrorKind, ParseError};
 use nom::Err;
 use nom::IResult;
@@ -18,26 +19,36 @@ pub fn nom_input_error_with_kind(input: &[u8], kind: ErrorKind) -> Err<nom::erro
     Err::Error(nom::error::Error::from_error_kind(input, kind))
 }
 
-#[derive(Debug)]
 /// Indexed Color identifiers used for memory cues and tracks.
+#[derive(Debug, PartialEq)]
+#[binread]
 pub enum ColorIndex {
     /// No color.
+    #[br(magic = 0u8)]
     None,
     /// Pink color.
+    #[br(magic = 1u8)]
     Pink,
     /// Red color.
+    #[br(magic = 2u8)]
     Red,
     /// Orange color.
+    #[br(magic = 3u8)]
     Orange,
     /// Yellow color.
+    #[br(magic = 4u8)]
     Yellow,
     /// Green color.
+    #[br(magic = 5u8)]
     Green,
     /// Aqua color.
+    #[br(magic = 6u8)]
     Aqua,
     /// Blue color.
+    #[br(magic = 7u8)]
     Blue,
     /// Purple color.
+    #[br(magic = 8u8)]
     Purple,
     /// Unknown color.
     Unknown(u16),

--- a/tests/tests_anlz.rs.in
+++ b/tests/tests_anlz.rs.in
@@ -6,4 +6,9 @@ fn anlz_{name}() {{
     let mut reader = Cursor::new(data);
     let anlz = ANLZ::read(&mut reader).expect("failed to parse anlz file");
     println!("{{:#?}}", anlz);
+
+    let mut new_data = Vec::with_capacity(data.len());
+    let mut writer = Cursor::new(&mut new_data);
+    anlz.write_to(&mut writer).expect("failed to write anlz file");
+    assert_eq!(data, new_data);
 }}

--- a/tests/tests_anlz.rs.in
+++ b/tests/tests_anlz.rs.in
@@ -3,9 +3,7 @@
 fn anlz_{name}() {{
     println!("Parsing file: {filepath}");
     let data = include_bytes!("{filepath}").as_slice();
-    let (input, anlz) = ANLZ::parse(data).expect("failed to parse header");
-    println!("File Header: {{:#?}}", anlz);
-    for (i, section) in anlz.sections(input).enumerate() {{
-        println!("#{{}}: {{:#?}}", i, section);
-    }}
+    let mut reader = Cursor::new(data);
+    let anlz = ANLZ::read(&mut reader).expect("failed to parse anlz file");
+    println!("{{:#?}}", anlz);
 }}


### PR DESCRIPTION
Closes #46.