### PR TITLE
git-cliff support

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+name: Generate Changelog
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docs:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: "Print Rust version"
+        run:  rustc -vV
+
+      - name: "Install git-cliff"
+        run:  cargo install --version 0.9.2 git-cliff
+
+      - name: "Generate Changelog"
+        run: git-cliff --output CHANGELOG.md
+
+      - name: "Check if changes any changes were made"
+        run: echo "GIT_DIRTY=$(git diff --quiet ; printf "%d" "$?")" >> "${GITHUB_ENV}"
+
+      - name: "Commit new changelog"
+        uses: EndBug/add-and-commit@v5
+        if: env.GIT_DIRTY != null && env.GIT_DIRTY != "0"
+        with:
+          add: "CHANGELOG.md"
+          message: "chore(changelog): Update changelog after merge"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,80 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{% if commit.scope %}{{ commit.scope }}: {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+# changelog footer
+footer = """
+## [0.2.0] - 2022-10-09
+
+- Switch from `nom` to `binrw` to pave the way for serialization support in the future
+- Improve documentation and add contribution guide
+- Add new command-line interface, which now also offers a way list the playlist tree
+- Add support for reading and serializing `*SETTING.DAT` files
+- Add more tests
+- Various small bug fixes and improvements (e.g., using 8-bit color indices consistently)
+
+## [0.1.0] - 2022-02-10
+
+Initial release.
+"""
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = true
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^ci", group = "CI", skip = true},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Code Style", skip = true},
+    { message = "^test", group = "Testing"},
+    { message = "^chore\\(release\\): prepare for", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks", skip = true},
+    { message = "(pdb)", scope = "PDB files"},
+    { message = "(anlz)", scope = "ANLZ files"},
+    { message = "(setting)", scope = "SETTING.DAT files"},
+    { message = "(cli)", scope = "Command Line Interface"},
+    { body = ".*security", group = "Security"},
+]
+link_parsers = [
+    { pattern = "#(\\d+)", href = "https://github.com/Holzhaus/rekordcrate/issues/$1"},
+    { pattern = "RFC(\\d+)", text = "ietf-rfc$1", href = "https://datatracker.ietf.org/doc/html/rfc$1"},
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+# glob pattern for matching git tags
+tag_pattern = "v[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.[1-2].0"
+# regex for ignoring tags
+#ignore_tags = ""
+# sort the tags chronologically
+date_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
We didn't use conventiona commits in the past, therefore we need to wait until 0.1.1 has been released before we can use `git-cliff`.

Based on #54.