### PR TITLE
Use 8-bit color indices consistently

### DIFF
--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -629,7 +629,7 @@ pub enum Row {
         /// Numeric color ID
         color: ColorIndex,
         /// Unknown field.
-        unknown3: u8,
+        unknown3: u16,
         /// User-defined name of the color.
         name: DeviceSQLString,
     },
@@ -898,8 +898,8 @@ impl Row {
     fn parse_color(input: &[u8]) -> IResult<&[u8], Row> {
         let (input, unknown1) = nom::number::complete::le_u32(input)?;
         let (input, unknown2) = nom::number::complete::u8(input)?;
-        let (input, color) = ColorIndex::parse_u16(input)?;
-        let (input, unknown3) = nom::number::complete::u8(input)?;
+        let (input, color) = ColorIndex::parse(input)?;
+        let (input, unknown3) = nom::number::complete::le_u16(input)?;
         let (input, name) = DeviceSQLString::parse(input)?;
         Ok((
             input,
@@ -1021,7 +1021,7 @@ impl Row {
         let (input, sample_depth) = nom::number::complete::le_u16(input)?;
         let (input, duration) = nom::number::complete::le_u16(input)?;
         let (input, unknown5) = nom::number::complete::le_u16(input)?;
-        let (input, color) = ColorIndex::parse_u8(input)?;
+        let (input, color) = ColorIndex::parse(input)?;
         let (input, rating) = nom::number::complete::u8(input)?;
         let (input, unknown6) = nom::number::complete::le_u16(input)?;
         let (input, unknown7) = nom::number::complete::le_u16(input)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -56,15 +56,9 @@ pub enum ColorIndex {
 
 impl ColorIndex {
     /// Parse an 8-bit color index from an input slice.
-    pub fn parse_u8(input: &[u8]) -> IResult<&[u8], Self> {
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, color_id) = nom::number::complete::u8(input)?;
         Ok((input, Self::from(u16::from(color_id))))
-    }
-
-    /// Parse a 16-bit color index from an input slice.
-    pub fn parse_u16(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, color_id) = nom::number::complete::le_u16(input)?;
-        Ok((input, Self::from(color_id)))
     }
 }
 


### PR DESCRIPTION
Before, we sometimes used 8-bit indices and sometimes 16-bit ones,
because the reverse-engineered format documentation described it that
way.

However, these does not seem to be a good reason why there should be
16-bit color indices when the value it contains is just 8-bit. It's
likely that the most significant byte actually belongs to another field.

Also see:

  https://github.com/Deep-Symmetry/crate-digger/issues/27