### PR TITLE
refactor: fix clippy warnings for rust 1.64

### DIFF
--- a/src/pdb/string.rs
+++ b/src/pdb/string.rs
@@ -202,7 +202,7 @@ impl LongBody {
             // ISRC offset is compensating for trailing nullbyte + 0x3 magic byte.
             Self::Isrc(null_str) => null_str.len() + 2,
             Self::Ascii(buf) => buf.len(),
-            Self::Ucs2le(buf) => (buf.len() * 2),
+            Self::Ucs2le(buf) => buf.len() * 2,
         }
         .try_into()
         .map_err(|_| StringError::TooLong)

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -66,7 +66,7 @@ pub struct Setting {
     /// See <https://reveng.sourceforge.io/crc-catalogue/all.htm#crc.cat.crc-16-xmodem> for
     /// details.
     #[br(temp)]
-    #[bw(calc = no_checksum.then(|| 0).unwrap_or_else(|| self.calculate_checksum()))]
+    #[bw(calc = no_checksum.then_some(0).unwrap_or_else(|| self.calculate_checksum()))]
     checksum: u16,
     /// Unknown field (apparently always `0000`).
     #[br(assert(unknown == 0))]


### PR DESCRIPTION
fixes 
```
warning: unnecessary parentheses around match arm expression
   --> src/pdb/string.rs:205:34
    |
205 |             Self::Ucs2le(buf) => (buf.len() * 2),
    |                                  ^             ^
    |
    = note: `#[warn(unused_parens)]` on by default
help: remove these parentheses
    |
205 -             Self::Ucs2le(buf) => (buf.len() * 2),
205 +             Self::Ucs2le(buf) => buf.len() * 2,
    |

error: unnecessary closure used with `bool::then`
  --> src/setting.rs:69:17
   |
69 |     #[bw(calc = no_checksum.then(|| 0).unwrap_or_else(|| self.calculate_checksum()))]
   |                 ^^^^^^^^^^^^----------
   |                             |
   |                             help: use `then_some(..)` instead: `then_some(0)`
   |
note: the lint level is defined here
  --> src/lib.rs:18:9
   |
18 | #![deny(clippy::all)]
   |         ^^^^^^^^^^^
   = note: `#[deny(clippy::unnecessary_lazy_evaluations)]` implied by `#[deny(clippy::all)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

```