### PR TITLE
refactor: update to `binrw` 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,20 +10,22 @@ checksum = "bfb6d71005dc22a708c7496eee5c8dc0300ee47355de6256c3b35b12b5fef596"
 
 [[package]]
 name = "binrw"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abb4fd60add897b9e8827e0d5fa6c2ca129ece2432d9aa13454b21ac2ecc18f"
+checksum = "f846d8732b2a55b569b885852ecc925a2b1f24568f4707f8b1ccd5dc6805ea9b"
 dependencies = [
  "array-init",
  "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
 name = "binrw_derive"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a36ff195a3a1a82d5eeb98e0069bdf3ea076042d28591396d9020fac763bf66f"
+checksum = "5c2aa66a5e35daf7f91ed44c945886597ef4c327f34f68b6bbf22951a250ceeb"
 dependencies = [
+ "either",
  "owo-colors",
  "proc-macro2",
  "quote",
@@ -31,10 +33,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+
+[[package]]
 name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "glob"
@@ -71,9 +85,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -105,9 +119,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -116,6 +130,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = [".*"]
 
 [dependencies]
-binrw = "0.9"
+binrw = "0.10"
 modular-bitfield = "0.11"
 crc16 = "0.4"
 

--- a/src/anlz.rs
+++ b/src/anlz.rs
@@ -226,7 +226,7 @@ pub struct Cue {
 
 /// A memory or hot cue (or loop).
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[brw(big)]
 pub struct ExtendedCue {
     /// Cue entry header.
@@ -525,58 +525,58 @@ pub struct Phrase {
 
 /// Section content which differs depending on the section type.
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[br(import(header: Header))]
 pub enum Content {
     /// All beats in the track.
-    #[brw(pre_assert(header.kind == ContentKind::BeatGrid))]
+    #[br(pre_assert(header.kind == ContentKind::BeatGrid))]
     BeatGrid(BeatGrid),
     /// List of cue points or loops (either hot cues or memory cues).
-    #[brw(pre_assert(header.kind == ContentKind::CueList))]
+    #[br(pre_assert(header.kind == ContentKind::CueList))]
     CueList(CueList),
     /// List of cue points or loops (either hot cues or memory cues, extended version).
     ///
     /// Variation of the original `CueList` that also adds support for more metadata such as
     /// comments and colors. Introduces with the Nexus 2 series players.
-    #[brw(pre_assert(header.kind == ContentKind::ExtendedCueList))]
+    #[br(pre_assert(header.kind == ContentKind::ExtendedCueList))]
     ExtendedCueList(ExtendedCueList),
     /// Path of the audio file that this analysis belongs to.
-    #[brw(pre_assert(header.kind == ContentKind::Path))]
+    #[br(pre_assert(header.kind == ContentKind::Path))]
     Path(#[br(args(header.clone()))] Path),
     /// Seek information for variable bitrate files (probably).
-    #[brw(pre_assert(header.kind == ContentKind::VBR))]
+    #[br(pre_assert(header.kind == ContentKind::VBR))]
     VBR(#[br(args(header.clone()))] VBR),
     /// Fixed-width monochrome preview of the track waveform.
-    #[brw(pre_assert(header.kind == ContentKind::WaveformPreview))]
+    #[br(pre_assert(header.kind == ContentKind::WaveformPreview))]
     WaveformPreview(#[br(args(header.clone()))] WaveformPreview),
     /// Smaller version of the fixed-width monochrome preview of the track waveform.
-    #[brw(pre_assert(header.kind == ContentKind::TinyWaveformPreview))]
+    #[br(pre_assert(header.kind == ContentKind::TinyWaveformPreview))]
     TinyWaveformPreview(#[br(args(header.clone()))] TinyWaveformPreview),
     /// Variable-width large monochrome version of the track waveform.
     ///
     /// Used in `.EXT` files.
-    #[brw(pre_assert(header.kind == ContentKind::WaveformDetail))]
+    #[br(pre_assert(header.kind == ContentKind::WaveformDetail))]
     WaveformDetail(#[br(args(header.clone()))] WaveformDetail),
     /// Variable-width large monochrome version of the track waveform.
     ///
     /// Used in `.EXT` files.
-    #[brw(pre_assert(header.kind == ContentKind::WaveformColorPreview))]
+    #[br(pre_assert(header.kind == ContentKind::WaveformColorPreview))]
     WaveformColorPreview(#[br(args(header.clone()))] WaveformColorPreview),
     /// Variable-width large colored version of the track waveform.
     ///
     /// Used in `.EXT` files.
-    #[brw(pre_assert(header.kind == ContentKind::WaveformColorDetail))]
+    #[br(pre_assert(header.kind == ContentKind::WaveformColorDetail))]
     WaveformColorDetail(#[br(args(header.clone()))] WaveformColorDetail),
     /// Describes the structure of a sond (Intro, Chrous, Verse, etc.).
     ///
     /// Used in `.EXT` files.
-    #[brw(pre_assert(header.kind == ContentKind::SongStructure))]
+    #[br(pre_assert(header.kind == ContentKind::SongStructure))]
     SongStructure(#[br(args(header.clone()))] SongStructure),
     /// Unknown content.
     ///
     /// This allows handling files that contain unknown section types and allows to access later
     /// sections in the file that have a known type instead of failing to parse the whole file.
-    #[brw(pre_assert(matches!(header.kind, ContentKind::Unknown(_))))]
+    #[br(pre_assert(matches!(header.kind, ContentKind::Unknown(_))))]
     Unknown(#[br(args(header.clone()))] Unknown),
 }
 
@@ -623,7 +623,7 @@ pub struct CueList {
 /// Variation of the original `CueList` that also adds support for more metadata such as
 /// comments and colors. Introduces with the Nexus 2 series players.
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ExtendedCueList {
     /// The types of cues (memory or hot) that this list contains.
     pub list_type: CueListType,
@@ -641,7 +641,7 @@ pub struct ExtendedCueList {
 
 /// Path of the audio file that this analysis belongs to.
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[br(import(header: Header))]
 pub struct Path {
     /// Length of the path field in bytes.
@@ -912,7 +912,7 @@ pub struct Unknown {
 
 /// ANLZ Section.
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Section {
     /// The header.
     pub header: Header,
@@ -926,7 +926,7 @@ pub struct Section {
 /// The actual contents are not part of this struct and can parsed on-the-fly by iterating over the
 /// `ANLZ::sections()` method.
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[brw(big)]
 pub struct ANLZ {
     /// The file header.

--- a/src/bin/rekordcrate-pdb.rs
+++ b/src/bin/rekordcrate-pdb.rs
@@ -21,7 +21,7 @@ fn main() {
         for page in header
             .read_pages(
                 &mut reader,
-                &ReadOptions::default(),
+                &ReadOptions::new(binrw::Endian::NATIVE),
                 (&table.first_page, &table.last_page),
             )
             .unwrap()

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -720,6 +720,12 @@ pub struct Track {
     file_path: DeviceSQLString,
 }
 
+// #[bw(little)] on #[binread] types does
+// not seem to work so we manually define the endianness here.
+impl binrw::meta::WriteEndian for Track {
+    const ENDIAN: binrw::meta::EndianKind = binrw::meta::EndianKind::Endian(Endian::Little);
+}
+
 impl BinWrite for Track {
     type Args = ();
 
@@ -729,7 +735,7 @@ impl BinWrite for Track {
         options: &WriteOptions,
         _args: Self::Args,
     ) -> BinResult<()> {
-        let options = &options.clone().with_endian(Endian::Little);
+        debug_assert!(options.endian() == Endian::Little);
 
         let base_position = writer.stream_position()?;
         self.unknown1.write_options(writer, options, ())?;

--- a/src/pdb/string.rs
+++ b/src/pdb/string.rs
@@ -11,8 +11,8 @@
 //!
 //! See <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/exports.html#devicesql-strings>
 
-use binrw::{binrw, NullString};
-use std::fmt;
+use binrw::binrw;
+use std::{convert::TryInto, fmt};
 
 const MAX_SHORTSTR_SIZE: usize = ((u8::MAX >> 1) - 1) as usize;
 
@@ -41,7 +41,7 @@ pub enum StringError {
 /// let binary = vec![0x9, 0x66, 0x6F, 0x6F];
 ///
 /// let mut writer = binrw::io::Cursor::new(vec![]);
-/// string.write_to(&mut writer)?;
+/// string.write(&mut writer)?;
 /// assert_eq!(&binary, writer.get_ref());
 ///
 /// let mut reader = binrw::io::Cursor::new(binary);
@@ -52,6 +52,7 @@ pub enum StringError {
 /// ```
 #[derive(PartialEq, Clone)]
 #[binrw]
+#[brw(little)]
 pub struct DeviceSQLString(DeviceSQLStringImpl);
 impl DeviceSQLString {
     /// Initializes a [`DeviceSQLString`] from a plain Rust [`std::string::String`]
@@ -95,7 +96,7 @@ impl DeviceSQLString {
             return Err(StringError::InvalidISRC);
         }
         Ok(Self(DeviceSQLStringImpl::Long {
-            content: LongBody::Isrc(NullString::from_string(string)),
+            content: LongBody::Isrc(string.into()),
         }))
     }
 
@@ -112,9 +113,7 @@ impl DeviceSQLString {
             DeviceSQLStringImpl::Long {
                 content: LongBody::Isrc(str),
                 ..
-            } => str
-                .into_string_lossless()
-                .map_err(|_| StringError::Encoding),
+            } => str.try_into().map_err(|_| StringError::Encoding),
             DeviceSQLStringImpl::Long {
                 content: LongBody::Ucs2le(vec),
             } => String::from_utf16(&vec).map_err(|_| StringError::Encoding),

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -25,7 +25,7 @@
 use binrw::{binrw, io::Cursor, BinWrite, Endian, NullString, WriteOptions};
 
 #[binrw]
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[brw(little)]
 #[bw(import(no_checksum: bool))]
 /// Represents a setting file.

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,16 +45,19 @@ pub enum ColorIndex {
 
 #[cfg(test)]
 pub(crate) mod testing {
-    use binrw::prelude::*;
+    use binrw::{
+        meta::{ReadEndian, WriteEndian},
+        prelude::*,
+    };
     pub fn test_roundtrip<T>(bin: &[u8], obj: T)
     where
         <T as binrw::BinRead>::Args: Default,
         <T as binrw::BinWrite>::Args: Default,
-        T: BinRead + BinWrite + PartialEq + core::fmt::Debug,
+        T: BinRead + BinWrite + PartialEq + core::fmt::Debug + ReadEndian + WriteEndian,
     {
         // T->binary
         let mut writer = binrw::io::Cursor::new(Vec::with_capacity(bin.len()));
-        obj.write_to(&mut writer).unwrap();
+        obj.write(&mut writer).unwrap();
         assert_eq!(bin, writer.get_ref());
         // T->binary->T
         writer.set_position(0);
@@ -66,7 +69,7 @@ pub(crate) mod testing {
         assert_eq!(obj, parsed);
         // binary->T->binary
         writer.set_position(0);
-        parsed.write_to(&mut writer).unwrap();
+        parsed.write(&mut writer).unwrap();
         assert_eq!(bin, writer.get_ref());
     }
 }

--- a/tests/tests_anlz.rs.in
+++ b/tests/tests_anlz.rs.in
@@ -9,6 +9,6 @@ fn anlz_{name}() {{
 
     let mut new_data = Vec::with_capacity(data.len());
     let mut writer = Cursor::new(&mut new_data);
-    anlz.write_to(&mut writer).expect("failed to write anlz file");
+    anlz.write(&mut writer).expect("failed to write anlz file");
     assert_eq!(data, new_data);
 }}

--- a/tests/tests_pdb.rs.in
+++ b/tests/tests_pdb.rs.in
@@ -11,7 +11,7 @@ fn pdb_{name}() {{
         println!("Table {{}}: {{:?}}", i, table.page_type);
         let pages = header.read_pages(
                 &mut reader,
-                &ReadOptions::default(),
+                &ReadOptions::new(binrw::Endian::NATIVE),
                 (&table.first_page, &table.last_page),
             )
             .expect("failed to read pages");

--- a/tests/tests_setting.rs.in
+++ b/tests/tests_setting.rs.in
@@ -9,6 +9,6 @@ fn setting_{name}() {{
 
     let mut new_data = Vec::with_capacity(data.len());
     let mut writer = Cursor::new(&mut new_data);
-    setting.write_to(&mut writer).expect("failed to write setting file");
+    setting.write(&mut writer).expect("failed to write setting file");
     assert_eq!(data, new_data);
 }}


### PR DESCRIPTION
unfortunately in order to keep CI green, a bunch of things were updated in parallel. (making cargo fmt, clippy, etc happy while also introducing the changes necessary for binrw 0.10). 

If you insist, I can try to reorder and split some of the changes. 