### PR TITLE
build(cargo): Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rekordcrate"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Jan Holthuis <jan.holthuis@ruhr-uni-bochum.de>"]
 description = "Library for parsing Pioneer Rekordbox device exports"
 readme = "README.md"


### PR DESCRIPTION
Since v0.1.0 we switched from `nom` to `binrw` and added support for parsing `*SETTING.DAT` files, so it's really more than just a bug fix release. Although the switch to `binrw` is an API change, the major we don't want to bump the version `1` in order to emphasize that the API is not finalized and subject to changes.