### PR TITLE
chore(changelog): update action versions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -28,10 +28,8 @@ jobs:
         run: echo "GIT_DIRTY=$(git diff --quiet ; printf "%d" "$?")" >> "${GITHUB_ENV}"
 
       - name: "Commit new changelog"
-        uses: EndBug/add-and-commit@v5
+        uses: EndBug/add-and-commit@v9
         if: env.GIT_DIRTY != null && env.GIT_DIRTY != '0'
         with:
           add: "CHANGELOG.md"
           message: "chore(changelog): Update changelog after merge"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixing this warning. 
![Screenshot from 2022-10-10 19-28-30](https://user-images.githubusercontent.com/12380386/194922322-3a3de73f-4578-45ed-9c80-c69b32331f26.png)

Updated `EndBug/add-and-commit` as well. I removed the manual token passing. According to [a section in the Changelog](https://github.com/EndBug/add-and-commit/blob/90fb64e03a6338b2495d967c36266e0639dd104e/CHANGELOG.md#700---2021-01-16) the action will use the GITHUB_ by default. 