### PR TITLE
Cache git cliff

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -28,10 +28,8 @@ jobs:
         run: echo "GIT_DIRTY=$(git diff --quiet ; printf "%d" "$?")" >> "${GITHUB_ENV}"
 
       - name: "Commit new changelog"
-        uses: EndBug/add-and-commit@v5
+        uses: EndBug/add-and-commit@v9
         if: env.GIT_DIRTY != null && env.GIT_DIRTY != '0'
         with:
           add: "CHANGELOG.md"
           message: "chore(changelog): Update changelog after merge"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Use cached artifacts"
+        uses: Swatinem/rust-cache@v2
+
       - name: "Print Rust version"
         run:  rustc -vV
 


### PR DESCRIPTION
Based on #88.

Caches dependencies and binary itself. Reduces runtime from [5m 30s](https://github.com/Swiftb0y/rekordcrate/actions/runs/3221376924/jobs/5269234935) to [7s](https://github.com/Swiftb0y/rekordcrate/actions/runs/3221439757/jobs/5269376216). 