### PR TITLE
style(lint): only warn on missing docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,11 @@
 //! This library provides access to device libraries exported from Pioneer's Rekordbox DJ software.
 
 #![warn(unsafe_code)]
+#![warn(missing_docs)]
 #![cfg_attr(not(debug_assertions), deny(warnings))]
 #![deny(rust_2018_idioms)]
 #![deny(rust_2021_compatibility)]
 #![deny(missing_debug_implementations)]
-#![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::all)]
 #![deny(clippy::explicit_deref_methods)]


### PR DESCRIPTION
Otherwise the build fails when you just want to prototype. The workaround of spamming `/// TODO` everywhere leads to oversights.