### PR TITLE
refactor(pdb): Use `bitflags` crate for page flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ name = "rekordcrate"
 version = "0.2.0"
 dependencies = [
  "binrw",
+ "bitflags",
  "clap",
  "crc16",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ exclude = [".*"]
 [dependencies]
 binrw = "0.10"
 modular-bitfield = "0.11"
+bitflags = "1.3"
 crc16 = "0.4"
 clap = { version = "4.0.10", features = ["derive"], optional = true }
 parse-display = "0.6.0"


### PR DESCRIPTION
Idea how to improve the pageflags struct. Unsure if it already makes sense to merge this, because it introduces an additional dependency.

Resolves #95.