### PR TITLE
fix: Plain Hotcues being rejected due to cuetype mismatch

### DIFF
--- a/src/anlz.rs
+++ b/src/anlz.rs
@@ -153,7 +153,7 @@ pub enum CueListType {
 #[brw(repr = u8)]
 pub enum CueType {
     /// Cue is a single point.
-    Point = 0,
+    Point = 1,
     /// Cue is a loop.
     Loop = 2,
 }


### PR DESCRIPTION
Due to what is likely a typo, ANLZ files with plain (non-loop) hotcues are incorrectly rejected.
Found while investigating https://github.com/mixxxdj/mixxx/issues/14789 See https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#extended-cue-list

> The first “non-header” field is type at byte 10 (labeled t in the diagram), and it specifies whether the entry records a simple position (if it has the value 1) or a loop (if it has the value 2).

--- 

Couldn't be bothered to set up a regression test right now