### PR TITLE
refactor(pdb): remove unneeded explicit padding from tag rows

### DIFF
--- a/src/pdb/ext.rs
+++ b/src/pdb/ext.rs
@@ -20,7 +20,6 @@
 //! - <https://github.com/flesniak/python-prodj-link/tree/master/prodj/pdblib>
 
 use crate::pdb::{DeviceSQLString, OffsetArray, OffsetArrayContainer, Subtype, TrackId};
-use crate::util::ExplicitPadding;
 use binrw::binrw;
 use std::num::NonZero;
 
@@ -88,12 +87,10 @@ pub struct TagOrCategory {
     pub id: TagId,
     /// Non-zero if this row represents a category rather than a tag.
     pub raw_is_category: u32,
-    #[brw(args(0x1C, subtype.get_offset_size(), ()))]
+    // Padded at the end by 11 bytes as observed
+    #[brw(args(0x1C, subtype.get_offset_size(), ()), pad_after = 11)]
     /// The strings associated with this tag or category.
     pub offsets: OffsetArrayContainer<TagOrCategoryStrings, 3>,
-    #[br(args(0x20))]
-    /// Padding at the end of the struct (observed 11 bytes for this rows)
-    pub padding: ExplicitPadding,
 }
 
 // https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/exports.html#tag-track-rows

--- a/src/pdb/test.rs
+++ b/src/pdb/test.rs
@@ -9000,7 +9000,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9020,7 +9019,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9040,7 +9038,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9060,7 +9057,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9080,7 +9076,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9100,7 +9095,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9120,7 +9114,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9140,7 +9133,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9160,7 +9152,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9180,7 +9171,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9200,7 +9190,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9220,7 +9209,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9240,7 +9228,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9260,7 +9247,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9280,7 +9266,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[0]
@@ -9300,7 +9285,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
 
@@ -9321,7 +9305,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9341,7 +9324,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9361,7 +9343,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9381,7 +9362,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9401,7 +9381,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9421,7 +9400,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 11.into(),
         })))
         .unwrap();
     row_groups[1]
@@ -9441,7 +9419,6 @@ fn tag_page() {
                     unknown: "".parse().unwrap(),
                 },
             },
-            padding: 0.into(),
         })))
         .unwrap();
 


### PR DESCRIPTION
small PR, reduces the number of row types that use explicit padding to 3 (tracks, artists and albums)