### PR TITLE
JSON output support for dump commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -52,18 +52,18 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -78,9 +78,9 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "binrw"
@@ -103,26 +103,26 @@ dependencies = [
  "owo-colors",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -130,15 +130,15 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -179,7 +179,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -190,9 +190,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "core-foundation-sys"
@@ -214,9 +214,9 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "fallible-iterator"
@@ -225,10 +225,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.4"
+name = "faster-hex"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "glob"
@@ -244,9 +277,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -268,37 +301,44 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "modular-bitfield"
@@ -318,7 +358,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -332,21 +372,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "parse-display"
@@ -370,8 +410,14 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn",
+ "syn 2.0.119",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pretty-hex"
@@ -391,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -410,18 +456,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -431,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -442,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rekordcrate"
@@ -455,6 +501,7 @@ dependencies = [
  "clap",
  "crc16",
  "fallible-iterator",
+ "faster-hex",
  "glob",
  "modular-bitfield",
  "parse-display",
@@ -463,30 +510,31 @@ dependencies = [
  "quick-xml",
  "rgb",
  "serde",
+ "serde_json",
  "serde_repr",
  "thiserror",
 ]
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -494,40 +542,59 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.0",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "static_assertions"
@@ -550,7 +617,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -561,14 +628,25 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -577,29 +655,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.0",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -609,9 +687,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -621,24 +699,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -646,22 +710,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
- "wasm-bindgen-backend",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -687,7 +751,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -698,7 +762,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -727,80 +791,21 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,9 @@ parse-display = "0.11"
 thiserror = "2.0"
 quick-xml = { version = "0.40.1", features = ["serialize", "serde-types"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 serde_repr = { version = "0.1.19", optional = true }
+faster-hex = { version = "0.9", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 rgb = { version = "0.8", optional = true }
 fallible-iterator = "0.3.0"
@@ -33,9 +35,10 @@ pretty-hex = "0.4"
 pretty_assertions = "1"
 
 [features]
-default = ["cli", "xml"]
+default = ["cli", "xml", "json"]
 cli = ["dep:clap"]
 xml = ["dep:serde", "dep:serde_repr", "dep:quick-xml", "dep:chrono", "dep:rgb"]
+json = ["dep:serde", "dep:serde_json", "dep:faster-hex"]
 
 [[bin]]
 name = "rekordcrate"

--- a/README.md
+++ b/README.md
@@ -12,15 +12,18 @@ have breaking API changes in the future.
 
 ## Command Line Usage
 
-This library includes a command line tool named `rekordcrate` to inspect
-database exports (i.e. `PIONEER/rekordbox/export.pdb` files):
+The included command line tool `rekordcrate` can be used to inspect various files.
+
+By default, it will output `Debug` trait output. pass `--format json` (or `-f json`) to any `dump-*` command to get JSON output instead.
+
+To inspect database exports (i.e. `PIONEER/rekordbox/export.pdb` files):
 
     $ cargo run -- dump-pdb data/complete_export/demo-tracks/PIONEER/rekordbox/export.pdb
 
 Analysis files (`.DAT`, `.EXT` and `.2EX` files in the `PIONEER/USBANLZ`
 directory) can also be viewed:
 
-    $ cargo run -- dump-anlz -- data/complete_export/demo_tracks/PIONEER/USBANLZ/P016/0000875E/ANLZ0000.DAT
+    $ cargo run -- dump-anlz data/complete_export/demo_tracks/PIONEER/USBANLZ/P016/0000875E/ANLZ0000.DAT
 
 The tool is also able to display the contents of `*SETTING.DAT` files
 (`DEVSETTING.DAT`, `DJMMYSETTING.DAT`, `MYSETTING.DAT` and `MYSETTING2.DAT`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ have breaking API changes in the future.
 
 The included command line tool `rekordcrate` can be used to inspect various files.
 
-By default, it will output `Debug` trait output. pass `--format json` (or `-f json`) to any `dump-*` command to get JSON output instead.
+By default, it will output `Debug` trait output. Pass `--format json` (or `-f json`) to any `dump-*` command to get JSON output instead.
 
 To inspect database exports (i.e. `PIONEER/rekordbox/export.pdb` files):
 

--- a/src/anlz.rs
+++ b/src/anlz.rs
@@ -26,6 +26,8 @@
 
 #![allow(clippy::must_use_candidate)]
 
+#[cfg(feature = "json")]
+use crate::util::serialize_as_hex;
 use crate::{util::ColorIndex, xor::XorStream};
 use binrw::{
     binrw,
@@ -33,10 +35,21 @@ use binrw::{
     BinRead, BinResult, BinWrite, Endian, NullWideString,
 };
 use modular_bitfield::prelude::*;
+#[cfg(feature = "json")]
+use serde::{Serialize, Serializer};
+
+#[cfg(feature = "json")]
+fn serialize_null_wide_string<S>(nws: &NullWideString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&nws.to_string())
+}
 
 /// The kind of section.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub enum ContentKind {
     /// File section that contains all other sections.
@@ -113,6 +126,7 @@ pub enum ContentKind {
 /// Header of a section that contains type and size information.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Header {
     /// Kind of content in this item.
@@ -136,6 +150,7 @@ impl Header {
 /// A single beat inside the beat grid.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Beat {
     /// Beat number inside the bar (1-4).
@@ -149,6 +164,7 @@ pub struct Beat {
 /// Describes the types of entries found in a Cue List section.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big, repr = u32)]
 pub enum CueListType {
     /// Memory cues or loops.
@@ -160,6 +176,7 @@ pub enum CueListType {
 /// Indicates if the cue is point or a loop.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum CueType {
     /// Cue is a single point.
@@ -171,6 +188,7 @@ pub enum CueType {
 /// A memory or hot cue (or loop).
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Cue {
     /// Cue entry header.
@@ -248,6 +266,7 @@ pub struct Cue {
 /// ```
 /// Used for the `comment` field in the `ExtendedCue` section.
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct LenPrefixedWideString(pub String);
 
 impl LenPrefixedWideString {
@@ -338,6 +357,7 @@ impl BinWrite for LenPrefixedWideString {
 /// A memory or hot cue (or loop).
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct ExtendedCue {
     /// Cue entry header.
@@ -491,6 +511,20 @@ pub struct WaveformPreviewColumn {
     pub whiteness: B3,
 }
 
+#[cfg(feature = "json")]
+impl Serialize for WaveformPreviewColumn {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("WaveformPreviewColumn", 2)?;
+        state.serialize_field("height", &self.height())?;
+        state.serialize_field("whiteness", &self.whiteness())?;
+        state.end()
+    }
+}
+
 impl Default for TinyWaveformPreviewColumn {
     fn default() -> Self {
         Self::new()
@@ -512,12 +546,27 @@ pub struct TinyWaveformPreviewColumn {
     pub height: B4,
 }
 
+#[cfg(feature = "json")]
+impl Serialize for TinyWaveformPreviewColumn {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("TinyWaveformPreviewColumn", 2)?;
+        state.serialize_field("unused", &self.unused())?;
+        state.serialize_field("height", &self.height())?;
+        state.end()
+    }
+}
+
 /// Single Column value in a Waveform Color Preview.
 ///
 /// See these the documentation for details:
 /// <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#color-preview>
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct WaveformColorPreviewColumn {
     /// Unknown field (somehow encodes the "whiteness").
@@ -546,6 +595,7 @@ impl Default for WaveformColorDetailColumn {
 /// <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#color-detail>
 #[bitfield]
 #[derive(BinRead, BinWrite, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(map = Self::from_bytes)]
 #[bw(big, map = |x: &WaveformColorDetailColumn| x.into_bytes())]
 pub struct WaveformColorDetailColumn {
@@ -568,6 +618,7 @@ pub struct WaveformColorDetailColumn {
 /// <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#three-band-preview>
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Waveform3BandPreviewColumn {
     /// Sound energy in the mid of the frequency range.
@@ -584,6 +635,7 @@ pub struct Waveform3BandPreviewColumn {
 /// <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#three-band-detail>
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Waveform3BandDetailColumn {
     /// Sound energy in the mid of the frequency range.
@@ -598,6 +650,7 @@ pub struct Waveform3BandDetailColumn {
 /// sound density.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big, repr = u16)]
 pub enum Mood {
     /// Phrase types consist of "Intro", "Up", "Down", "Chorus", and "Outro". Other values in each
@@ -617,6 +670,7 @@ pub enum Mood {
 /// Stylistic track bank for Lightning mode.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum Bank {
     /// Default bank variant, treated as `Cool`.
@@ -642,6 +696,7 @@ pub enum Bank {
 /// A song structure entry that represents a phrase in the track.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct Phrase {
     /// Phrase number (starting at 1).
@@ -698,6 +753,7 @@ pub struct Phrase {
 /// Section content which differs depending on the section type.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub enum Content {
     /// All beats in the track.
@@ -765,6 +821,7 @@ pub enum Content {
 /// All beats in the track.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct BeatGrid {
     /// Unknown field.
     unknown1: u32,
@@ -775,6 +832,7 @@ pub struct BeatGrid {
     /// Number of beats in this beatgrid.
     #[br(temp)]
     #[bw(calc = beats.len() as u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_beats: u32,
     /// Beats in this beatgrid.
     #[br(count = len_beats)]
@@ -784,6 +842,7 @@ pub struct BeatGrid {
 /// List of cue points or loops (either hot cues or memory cues).
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct CueList {
     /// The types of cues (memory or hot) that this list contains.
     pub list_type: CueListType,
@@ -792,6 +851,7 @@ pub struct CueList {
     /// Number of cues.
     #[br(temp)]
     #[bw(calc = cues.len() as u16)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_cues: u16,
     /// Unknown field.
     memory_count: u32,
@@ -806,12 +866,14 @@ pub struct CueList {
 /// comments and colors. Introduces with the Nexus 2 series players.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct ExtendedCueList {
     /// The types of cues (memory or hot) that this list contains.
     pub list_type: CueListType,
     /// Number of cues.
     #[br(temp)]
     #[bw(calc = cues.len() as u16)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_cues: u16,
     /// Unknown field
     #[br(assert(unknown == 0))]
@@ -824,40 +886,47 @@ pub struct ExtendedCueList {
 /// Path of the audio file that this analysis belongs to.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct Path {
     /// Length of the path field in bytes.
     #[br(temp)]
     #[br(assert(len_path == header.content_size()))]
     #[bw(calc = ((path.len() as u32) + 1) * 2)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_path: u32,
     /// Path of the audio file.
     #[br(assert(len_path == header.content_size()))]
     #[br(assert((path.len() as u32 + 1) * 2 == len_path))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_null_wide_string"))]
     pub path: NullWideString,
 }
 
 /// Seek information for variable bitrate files (probably).
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct VBR {
     /// Unknown field.
     unknown1: u32,
     /// Unknown data.
     #[br(count = header.content_size())]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown2: Vec<u8>,
 }
 
 /// Fixed-width monochrome preview of the track waveform.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct WaveformPreview {
     /// Unknown field.
     #[br(temp)]
     #[br(assert(len_preview == header.content_size()))]
     #[bw(calc = data.len() as u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_preview: u32,
     /// Unknown field (apparently always `0x00100000`)
     unknown: u32,
@@ -869,12 +938,14 @@ pub struct WaveformPreview {
 /// Smaller version of the fixed-width monochrome preview of the track waveform.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct TinyWaveformPreview {
     /// Unknown field.
     #[br(temp)]
     #[br(assert(len_preview == header.content_size()))]
     #[bw(calc = data.len() as u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_preview: u32,
     /// Unknown field (apparently always `0x00100000`)
     unknown: u32,
@@ -888,17 +959,20 @@ pub struct TinyWaveformPreview {
 /// Used in `.EXT` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct WaveformDetail {
     /// Size of a single entry, always 1.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 1))]
     #[bw(calc = 1u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[bw(calc = data.len() as u32)]
     #[br(assert((len_entry_bytes * len_entries)== header.content_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u32,
     /// Unknown field (apparently always `0x00960000`)
     #[br(assert(unknown == 0x00960000))]
@@ -916,17 +990,20 @@ pub struct WaveformDetail {
 /// Used in `.EXT` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct WaveformColorPreview {
     /// Size of a single entry, always 6.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 6))]
     #[bw(calc = 6u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[bw(calc = data.len() as u32)]
     #[br(assert((len_entry_bytes * len_entries) == header.content_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u32,
     /// Unknown field.
     unknown: u32,
@@ -940,17 +1017,20 @@ pub struct WaveformColorPreview {
 /// Used in `.EXT` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct WaveformColorDetail {
     /// Size of a single entry, always 2.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 2))]
     #[bw(calc = 2u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[bw(calc = data.len() as u32)]
     #[br(assert((len_entry_bytes * len_entries) == header.content_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u32,
     /// Unknown field.
     unknown: u32,
@@ -967,17 +1047,20 @@ pub struct WaveformColorDetail {
 /// Used in `.2EX` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct Waveform3BandPreview {
     /// Size of a single entry, always 3.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 3))]
     #[bw(calc = 3u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[bw(calc = data.len() as u32)]
     #[br(assert((len_entry_bytes * len_entries) == header.content_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u32,
     /// Waveform preview column data.
     #[br(count = len_entries)]
@@ -989,17 +1072,20 @@ pub struct Waveform3BandPreview {
 /// Used in `.2EX` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct Waveform3BandDetail {
     /// Size of a single entry, always 3.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 3))]
     #[bw(calc = 3u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[bw(calc = data.len() as u32)]
     #[br(assert((len_entry_bytes * len_entries) == header.content_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u32,
     /// Unknown field (apparently always `0x00960000`)
     #[br(assert(unknown == 0x00960000))]
@@ -1017,23 +1103,27 @@ pub struct Waveform3BandDetail {
 /// Used in `.EXT` files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct SongStructure {
     /// Size of a single entry, always 24.
     #[br(temp)]
     #[br(assert(len_entry_bytes == 24))]
     #[bw(calc = 24u32)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entry_bytes: u32,
     /// Number of entries in this section.
     #[br(temp)]
     #[br(assert((len_entry_bytes * (len_entries as u32)) == header.content_size()))]
     #[bw(calc = data.phrases.len() as u16)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_entries: u16,
     /// Indicates if the remaining parts of the song structure section are encrypted.
     ///
     /// This is a virtual field and not actually present in the file.
     #[br(restore_position, map = |raw_mood: [u8; 2]| SongStructureData::check_if_encrypted(raw_mood, len_entries))]
     #[bw(ignore)]
+    #[cfg_attr(feature = "json", serde(skip))]
     is_encrypted: bool,
     /// Song structure data.
     #[br(args(is_encrypted, len_entries), parse_with = SongStructureData::read_encrypted)]
@@ -1047,6 +1137,7 @@ pub struct SongStructure {
 /// - <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/anlz.html#song-structure-tag>
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(len_entries: u16))]
 pub struct SongStructureData {
     /// Overall type of phrase structure.
@@ -1132,6 +1223,7 @@ impl SongStructureData {
 /// Unknown content.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(import(header: Header))]
 pub struct Unknown {
     /// Unknown header data.
@@ -1145,6 +1237,7 @@ pub struct Unknown {
 /// ANLZ Section.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct Section {
     /// The header.
     pub header: Header,
@@ -1159,6 +1252,7 @@ pub struct Section {
 /// `ANLZ::sections()` method.
 #[binrw]
 #[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(big)]
 pub struct ANLZ {
     /// The file header.
@@ -1166,6 +1260,7 @@ pub struct ANLZ {
     pub header: Header,
     /// The header data.
     #[br(count = header.remaining_size())]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     pub header_data: Vec<u8>,
     /// The content sections.
     #[br(parse_with = Self::parse_sections, args(header.content_size()))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,10 +310,7 @@ fn dump_anlz(path: &Path, format: DumpFormat) -> rekordcrate::Result<()> {
     let anlz = ANLZ::read(&mut reader)?;
     match format {
         #[cfg(feature = "json")]
-        DumpFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&anlz).expect("failed to serialize ANLZ")
-        ),
+        DumpFormat::Json => println!("{}", serde_json::to_string_pretty(&anlz)?),
         DumpFormat::Debug => println!("{:#?}", anlz),
         #[cfg(not(feature = "json"))]
         _ => unreachable!("DumpFormat has no other variants without the json feature"),
@@ -368,10 +365,7 @@ fn dump_pdb(
             });
         }
         let dump = PdbDump { header, tables };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&dump).expect("failed to serialize PDB output")
-        );
+        println!("{}", serde_json::to_string_pretty(&dump)?);
         return Ok(());
     }
 
@@ -426,10 +420,7 @@ fn dump_setting(
 
     match format {
         #[cfg(feature = "json")]
-        DumpFormat::Json => println!(
-            "{}",
-            serde_json::to_string_pretty(&setting).expect("failed to serialize Setting")
-        ),
+        DumpFormat::Json => println!("{}", serde_json::to_string_pretty(&setting)?),
         DumpFormat::Debug => println!("{:#04x?}", setting),
         #[cfg(not(feature = "json"))]
         _ => unreachable!("DumpFormat has no other variants without the json feature"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use binrw::BinRead;
+#[cfg(feature = "json")]
+use clap::ValueEnum;
 use clap::{Parser, Subcommand};
 use fallible_iterator::FallibleIterator;
 use rekordcrate::device::get_playlists;
@@ -14,6 +16,8 @@ use rekordcrate::pdb::io::Database;
 use rekordcrate::pdb::*;
 use rekordcrate::setting::{Setting, SettingType};
 use rekordcrate::{anlz::ANLZ, util::TableIndex};
+#[cfg(feature = "json")]
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -24,6 +28,31 @@ use std::path::{Path, PathBuf};
 struct Cli {
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Output format for the dump commands. The `Json` variant is only available when the
+/// `json` feature is enabled.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum DumpFormat {
+    #[default]
+    Debug,
+    #[cfg(feature = "json")]
+    Json,
+}
+
+// ponytail: clap's ValueEnum derive needs the full variant list at expansion time, so the
+// cfg on `Json` means the `--format` flag simply doesn't offer `json` when the feature is off.
+#[cfg(feature = "json")]
+impl ValueEnum for DumpFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Debug, Self::Json]
+    }
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        Some(match self {
+            Self::Debug => clap::builder::PossibleValue::new("debug"),
+            Self::Json => clap::builder::PossibleValue::new("json"),
+        })
+    }
 }
 
 #[derive(Subcommand)]
@@ -54,6 +83,9 @@ enum Commands {
         /// File to parse.
         #[arg(value_name = "ANLZ_FILE")]
         path: PathBuf,
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = DumpFormat::Debug)]
+        format: DumpFormat,
     },
     /// Parse and dump a Pioneer Database (`.PDB`) file.
     DumpPDB {
@@ -66,6 +98,9 @@ enum Commands {
         /// Attempt to parse unknown table types instead of skipping them.
         #[arg(long)]
         parse_unknown_tables: bool,
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = DumpFormat::Debug)]
+        format: DumpFormat,
     },
     /// Parse and dump a Pioneer Settings (`*SETTING.DAT`) file.
     DumpSetting {
@@ -75,6 +110,9 @@ enum Commands {
         /// Setting type.
         #[arg(long, value_name = "SETTING_TYPE", value_parser = ["devsetting", "djmmysetting", "mysetting", "mysetting2"])]
         setting_type: Option<String>,
+        /// Output format.
+        #[arg(long, short = 'f', value_enum, default_value_t = DumpFormat::Debug)]
+        format: DumpFormat,
     },
     /// Parse and dump a Pioneer XML (`*.xml`) file.
     #[cfg(feature = "xml")]
@@ -87,7 +125,7 @@ enum Commands {
 
 fn list_playlists(path: &Path) -> rekordcrate::Result<()> {
     use rekordcrate::pdb::{PlaylistTreeNode, PlaylistTreeNodeId};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     let reader = File::open(path)?;
     let mut db = Database::open_non_persistent(reader, DatabaseType::Plain)?;
@@ -267,17 +305,75 @@ fn list_settings(path: &Path) -> rekordcrate::Result<()> {
     Ok(())
 }
 
-fn dump_anlz(path: &Path) -> rekordcrate::Result<()> {
+fn dump_anlz(path: &Path, format: DumpFormat) -> rekordcrate::Result<()> {
     let mut reader = File::open(path)?;
     let anlz = ANLZ::read(&mut reader)?;
-    println!("{:#?}", anlz);
+    match format {
+        #[cfg(feature = "json")]
+        DumpFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&anlz).expect("failed to serialize ANLZ")
+        ),
+        DumpFormat::Debug => println!("{:#?}", anlz),
+        #[cfg(not(feature = "json"))]
+        _ => unreachable!("DumpFormat has no other variants without the json feature"),
+    }
 
     Ok(())
 }
 
-fn dump_pdb(path: &Path, typ: DatabaseType, parse_unknown_tables: bool) -> rekordcrate::Result<()> {
+/// A table and all of its pages, for JSON serialization.
+#[cfg(feature = "json")]
+#[derive(Serialize)]
+struct TableDump {
+    page_type: PageType,
+    pages: Vec<Page>,
+}
+
+/// The full PDB dump (header + tables), for JSON serialization.
+#[cfg(feature = "json")]
+#[derive(Serialize)]
+struct PdbDump {
+    header: Header,
+    tables: Vec<TableDump>,
+}
+
+fn dump_pdb(
+    path: &Path,
+    typ: DatabaseType,
+    parse_unknown_tables: bool,
+    format: DumpFormat,
+) -> rekordcrate::Result<()> {
     let reader = File::open(path)?;
     let mut db = Database::open_non_persistent(reader, typ)?;
+
+    #[cfg(feature = "json")]
+    if matches!(format, DumpFormat::Json) {
+        let header = db.get_header().clone();
+        let mut tables = Vec::new();
+        for (i, table) in header.tables.iter().enumerate() {
+            let id = TableIndex::from(i);
+            // Honor the same skip rule as the debug path so JSON output stays consistent.
+            if matches!(table.page_type, PageType::Unknown(_)) && !parse_unknown_tables {
+                continue;
+            }
+            let mut pages = Vec::new();
+            let mut page_iter = db.iter_pages_for_table(id)?;
+            while let Some(page) = page_iter.next()? {
+                pages.push(page.clone());
+            }
+            tables.push(TableDump {
+                page_type: table.page_type,
+                pages,
+            });
+        }
+        let dump = PdbDump { header, tables };
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&dump).expect("failed to serialize PDB output")
+        );
+        return Ok(());
+    }
 
     println!("{:#?}", db.get_header());
 
@@ -320,11 +416,24 @@ fn dump_pdb(path: &Path, typ: DatabaseType, parse_unknown_tables: bool) -> rekor
     Ok(())
 }
 
-fn dump_setting(path: &Path, setting_type: SettingType) -> rekordcrate::Result<()> {
+fn dump_setting(
+    path: &Path,
+    setting_type: SettingType,
+    format: DumpFormat,
+) -> rekordcrate::Result<()> {
     let mut reader = File::open(path)?;
     let setting = Setting::read_args(&mut reader, (setting_type,))?;
 
-    println!("{:#04x?}", setting);
+    match format {
+        #[cfg(feature = "json")]
+        DumpFormat::Json => println!(
+            "{}",
+            serde_json::to_string_pretty(&setting).expect("failed to serialize Setting")
+        ),
+        DumpFormat::Debug => println!("{:#04x?}", setting),
+        #[cfg(not(feature = "json"))]
+        _ => unreachable!("DumpFormat has no other variants without the json feature"),
+    }
 
     Ok(())
 }
@@ -422,20 +531,25 @@ fn main() -> rekordcrate::Result<()> {
             path,
             db_type,
             parse_unknown_tables,
+            format,
         } => {
             let db_type = match guess_db_type(path, db_type.as_deref()) {
                 Some(db_type) => db_type,
                 None => return Ok(()), // TODO(Swiftb0y): turn into proper error;
             };
-            dump_pdb(path, db_type, *parse_unknown_tables)
+            dump_pdb(path, db_type, *parse_unknown_tables, *format)
         }
-        Commands::DumpANLZ { path } => dump_anlz(path),
-        Commands::DumpSetting { path, setting_type } => {
+        Commands::DumpANLZ { path, format } => dump_anlz(path, *format),
+        Commands::DumpSetting {
+            path,
+            setting_type,
+            format,
+        } => {
             let setting_type = match guess_setting_type(path, setting_type.as_deref()) {
                 Some(setting_type) => setting_type,
                 None => return Ok(()), // TODO: turn into proper error
             };
-            dump_setting(path, setting_type)
+            dump_setting(path, setting_type, *format)
         }
         #[cfg(feature = "xml")]
         Commands::DumpXML { path } => dump_xml(path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use binrw::BinRead;
-#[cfg(feature = "json")]
-use clap::ValueEnum;
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 use fallible_iterator::FallibleIterator;
 use rekordcrate::device::get_playlists;
 use rekordcrate::pdb::io::Database;
@@ -31,28 +29,15 @@ struct Cli {
 }
 
 /// Output format for the dump commands. The `Json` variant is only available when the
-/// `json` feature is enabled.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+/// `json` feature is enabled; clap's derive drops it from `--format`'s allowed values when absent.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 enum DumpFormat {
     #[default]
+    #[value(name = "debug")]
     Debug,
     #[cfg(feature = "json")]
+    #[value(name = "json")]
     Json,
-}
-
-// ponytail: clap's ValueEnum derive needs the full variant list at expansion time, so the
-// cfg on `Json` means the `--format` flag simply doesn't offer `json` when the feature is off.
-#[cfg(feature = "json")]
-impl ValueEnum for DumpFormat {
-    fn value_variants<'a>() -> &'a [Self] {
-        &[Self::Debug, Self::Json]
-    }
-    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
-        Some(match self {
-            Self::Debug => clap::builder::PossibleValue::new("debug"),
-            Self::Json => clap::builder::PossibleValue::new("json"),
-        })
-    }
 }
 
 #[derive(Subcommand)]
@@ -312,8 +297,6 @@ fn dump_anlz(path: &Path, format: DumpFormat) -> rekordcrate::Result<()> {
         #[cfg(feature = "json")]
         DumpFormat::Json => println!("{}", serde_json::to_string_pretty(&anlz)?),
         DumpFormat::Debug => println!("{:#?}", anlz),
-        #[cfg(not(feature = "json"))]
-        _ => unreachable!("DumpFormat has no other variants without the json feature"),
     }
 
     Ok(())
@@ -343,6 +326,11 @@ fn dump_pdb(
 ) -> rekordcrate::Result<()> {
     let reader = File::open(path)?;
     let mut db = Database::open_non_persistent(reader, typ)?;
+
+    // `format` is only consulted under the json feature; bind it to avoid an unused-variable
+    // warning when building with `cli` alone.
+    #[cfg(not(feature = "json"))]
+    let _ = format;
 
     #[cfg(feature = "json")]
     if matches!(format, DumpFormat::Json) {
@@ -422,8 +410,6 @@ fn dump_setting(
         #[cfg(feature = "json")]
         DumpFormat::Json => println!("{}", serde_json::to_string_pretty(&setting)?),
         DumpFormat::Debug => println!("{:#04x?}", setting),
-        #[cfg(not(feature = "json"))]
-        _ => unreachable!("DumpFormat has no other variants without the json feature"),
     }
 
     Ok(())

--- a/src/pdb/bitfields.rs
+++ b/src/pdb/bitfields.rs
@@ -13,6 +13,8 @@
 
 use binrw::{BinRead, BinWrite};
 use modular_bitfield::prelude::*;
+#[cfg(feature = "json")]
+use serde::{Serialize, Serializer};
 
 use crate::pdb::RowGroup;
 
@@ -26,6 +28,20 @@ use crate::pdb::RowGroup;
 pub struct PackedRowCounts {
     pub num_rows: B13,
     pub num_rows_valid: B11,
+}
+
+#[cfg(feature = "json")]
+impl Serialize for PackedRowCounts {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("PackedRowCounts", 2)?;
+        state.serialize_field("num_rows", &self.num_rows())?;
+        state.serialize_field("num_rows_valid", &self.num_rows_valid())?;
+        state.end()
+    }
 }
 
 impl Default for PackedRowCounts {
@@ -76,6 +92,7 @@ impl PackedRowCounts {
 /// bitfield definition is reversed compared to typical notation.
 #[bitfield(bits = 8)]
 #[derive(BinRead, BinWrite, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(little, map = Self::from_bytes)]
 #[bw(little, map = |x: &Self| x.into_bytes())]
 pub struct PageFlags {

--- a/src/pdb/ext.rs
+++ b/src/pdb/ext.rs
@@ -24,11 +24,14 @@ use crate::pdb::{
     TrackId,
 };
 use binrw::binrw;
+#[cfg(feature = "json")]
+use serde::Serialize;
 use std::num::NonZero;
 
 /// A unique identifier for a tag or category.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct TagId(pub u32);
 
@@ -41,6 +44,7 @@ impl PageHeapObject for TagId {
 
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 /// A possibly absent parent ID. If the ID is zero (None), then there is no parent.
 pub struct ParentId(
@@ -58,6 +62,7 @@ impl PageHeapObject for ParentId {
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 /// The strings associated with a tag or category.
 pub struct TagOrCategoryStrings {
     /// The name of the tag or category.
@@ -86,6 +91,7 @@ impl OffsetArrayItems<2> for TagOrCategoryStrings {
 /// - <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/exports.html#tag-rows>
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct TagOrCategory {
     /// Determines if an 8-bit offset (0x0680) or a 16-bit offset (0x0684) is used for the strings.
@@ -138,6 +144,7 @@ impl PageHeapObject for TagOrCategory {
 /// M*N junction table between tags and tracks.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct TrackTag {
     #[brw(magic(0u32))]
@@ -167,6 +174,7 @@ impl PageHeapObject for TrackTag {
 #[binrw]
 #[brw(little)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum ExtPageType {
     /// can be assigned to tracks for the purpose of categorization.
     #[brw(magic = 3u32)]
@@ -179,6 +187,7 @@ pub enum ExtPageType {
 /// A table row contains the actual data.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 // #[br(import(page_type: PageType))]
 // The large enum size is unfortunate, but since users of this library will probably use iterators

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -685,7 +685,7 @@ pub struct DataPageContent {
     #[br(parse_with = parse_at_offsets(row_groups.iter().flat_map(RowGroup::present_rows_offsets)))]
     // `write_at_offsets` restores the writer position after writing.
     #[bw(write_with = write_at_offsets)]
-    #[br(assert(rows.len() == page_header.packed_row_counts.num_rows_valid().into(), "parsing page {:?}: num_rows_valid {} does not match parsed row count {}", page_header.page_index, page_header.packed_row_counts.num_rows_valid(), rows.len()))]
+    #[br(assert(rows.len() == page_header.packed_row_counts.num_rows_valid() as usize, "parsing page {:?}: num_rows_valid {} does not match parsed row count {}", page_header.page_index, page_header.packed_row_counts.num_rows_valid(), rows.len()))]
     pub rows: BTreeMap<u16, Row>,
 
     // Seek to the end of the data content area.

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -41,6 +41,8 @@ use crate::pdb::offset_array::OffsetSize;
 use crate::pdb::string::DeviceSQLString;
 use crate::util::{parse_at_offsets, write_at_offsets, ColorIndex, FileType, TableIndex};
 use binrw::{binrw, BinRead, BinResult, BinWrite, Endian};
+#[cfg(feature = "json")]
+use serde::Serialize;
 use std::io::{Read, Seek, SeekFrom, Write};
 use thiserror::Error;
 
@@ -58,6 +60,7 @@ pub enum PdbError {
 /// The type of the database were looking at.
 /// This influences the meaning of the the pagetypes found in tables.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum DatabaseType {
     #[default] // use plain by default for use of migration
     /// Standard export.pdb files.
@@ -69,6 +72,7 @@ pub enum DatabaseType {
 /// The type of pages found inside a `Table`.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(db_type: DatabaseType))]
 pub enum PageType {
@@ -85,6 +89,7 @@ pub enum PageType {
 /// The type of pages found inside a `Table` of export.pdb files.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub enum PlainPageType {
     /// Holds rows of track metadata, such as title, artist, genre, artwork ID, playing time, etc.
@@ -151,6 +156,7 @@ pub trait RowVariant {
 /// with the page size (found in the file header).
 #[binrw]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct PageIndex(pub(crate) u32);
 
@@ -178,6 +184,7 @@ impl PageIndex {
 /// into groups.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[brw(import(db_type: DatabaseType))]
 pub struct Table {
@@ -200,6 +207,7 @@ pub struct Table {
 /// The PDB header structure, including the list of tables.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[brw(import(db_type: DatabaseType))]
 pub struct Header {
@@ -250,6 +258,7 @@ impl Header {
 /// An entry in an index page.
 #[binrw]
 #[derive(PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct IndexEntry(u32);
 
@@ -316,6 +325,7 @@ impl fmt::Debug for IndexEntry {
 /// The header of the index-containing part of a page.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct IndexPageHeader {
     /// Unknown field, usually `0x1fff` or `0x0001`.
     pub unknown_a: u16,
@@ -354,6 +364,7 @@ impl IndexPageHeader {
 /// The content of an index page.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(little)]
 #[bw(little, import { page_size: u32 })]
 pub struct IndexPageContent {
@@ -371,6 +382,7 @@ pub struct IndexPageContent {
         Self::total_entries(page_size) - usize::from(header.num_entries)
     ))]
     #[bw(pad_after = 20)]
+    #[cfg_attr(feature = "json", serde(skip))]
     _empty_entries: EmptyIndexEntries,
 }
 
@@ -423,6 +435,7 @@ impl BinWrite for EmptyIndexEntries {
 /// Does not implement `Eq` due to the `Unknown` variant.
 #[binrw]
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(little, import { page_size: u32, header: &PageHeader })]
 #[bw(little, import { page_size: u32 })]
 pub enum PageContent {
@@ -497,6 +510,7 @@ impl PageContent {
 /// The header of a page.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(db_type: DatabaseType))]
 pub struct PageHeader {
@@ -549,6 +563,7 @@ impl PageHeader {
 /// offset found in the page footer at the end of the page.
 #[binrw]
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(page_size: u32, db_type: DatabaseType))]
 #[bw(import(page_size: u32))]
@@ -620,6 +635,7 @@ impl Page {
 /// The header of the data-containing part of a page.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct DataPageHeader {
     /// Unknown field.
     /// Often 1 or 0x1fff; also observed: 8, 27, 22, 17, 2.
@@ -648,6 +664,7 @@ impl DataPageHeader {
 /// The data-containing part of a page.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[br(little, import { page_size: u32, page_header: &PageHeader })]
 #[bw(little, import { page_size: u32 })]
 pub struct DataPageContent {
@@ -737,6 +754,7 @@ impl PageHeapObject for FileType {
 /// table.
 #[binrw]
 #[derive(Debug, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct RowGroup {
     /// An offset which points to a row in the table, whose actual presence is controlled by one of the
     /// bits in `row_present_flags`. This instance allows the row itself to be lazily loaded, unless it
@@ -765,6 +783,7 @@ pub struct RowGroup {
     #[br(temp)]
     #[bw(calc = ())]
     #[brw(seek_before = SeekFrom::Current(-i64::from(Self::BINARY_SIZE)))]
+    #[cfg_attr(feature = "json", serde(skip))]
     _dummy: (),
 }
 
@@ -839,6 +858,7 @@ impl PartialEq for RowGroup {
 /// Carries additional information about a row (if present, always as the first field of a row)
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Subtype(pub u16);
 
@@ -867,6 +887,7 @@ impl Subtype {
 /// Identifies a track.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct TrackId(pub u32);
 
@@ -880,6 +901,7 @@ impl PageHeapObject for TrackId {
 /// Identifies an artwork item.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct ArtworkId(pub u32);
 
@@ -893,6 +915,7 @@ impl PageHeapObject for ArtworkId {
 /// Identifies an album.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct AlbumId(pub u32);
 
@@ -906,6 +929,7 @@ impl PageHeapObject for AlbumId {
 /// Identifies an artist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct ArtistId(pub u32);
 
@@ -919,6 +943,7 @@ impl PageHeapObject for ArtistId {
 /// Identifies a genre.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct GenreId(pub u32);
 
@@ -932,6 +957,7 @@ impl PageHeapObject for GenreId {
 /// Identifies a key.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct KeyId(pub u32);
 
@@ -945,6 +971,7 @@ impl PageHeapObject for KeyId {
 /// Identifies a label.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct LabelId(pub u32);
 
@@ -958,6 +985,7 @@ impl PageHeapObject for LabelId {
 /// Identifies a playlist tree node.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct PlaylistTreeNodeId(pub u32);
 
@@ -971,6 +999,7 @@ impl PageHeapObject for PlaylistTreeNodeId {
 /// Identifies a history playlist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct HistoryPlaylistId(pub u32);
 
@@ -982,6 +1011,7 @@ impl PageHeapObject for HistoryPlaylistId {
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 /// Represents a trailing name field at the end of a row, used for album and artist names.
 pub struct TrailingName {
     /// The name a the end of the row this is used in
@@ -1004,6 +1034,7 @@ impl OffsetArrayItems<1> for TrailingName {
 /// Contains the album name, along with an ID of the corresponding artist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Album {
     /// Unknown field, usually `80 00`.
@@ -1062,6 +1093,7 @@ impl PageHeapObject for Album {
 /// Contains the artist name and ID.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Artist {
     /// Determines if the `name` string is located at the 8-bit offset (0x60) or the 16-bit offset (0x64).
@@ -1111,6 +1143,7 @@ impl PageHeapObject for Artist {
 /// Contains the artwork path and ID.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Artwork {
     /// ID of this row.
@@ -1151,6 +1184,7 @@ impl PageHeapObject for Artwork {
 /// Contains numeric color ID
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Color {
     /// Unknown field.
@@ -1200,6 +1234,7 @@ impl PageHeapObject for Color {
 /// Represents a musical genre.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Genre {
     /// ID of this row.
@@ -1240,6 +1275,7 @@ impl PageHeapObject for Genre {
 /// Represents a history playlist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct HistoryPlaylist {
     /// ID of this row.
@@ -1280,6 +1316,7 @@ impl PageHeapObject for HistoryPlaylist {
 /// Represents a history playlist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct HistoryEntry {
     /// ID of the track played at this position in the playlist.
@@ -1327,6 +1364,7 @@ impl PageHeapObject for HistoryEntry {
 /// them, so they can be used to track the history of changes to the database.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct History {
     /// Subtype field, in this case usually `80 02` (hex) or `640` (decimal).
@@ -1386,6 +1424,7 @@ impl RowVariant for History {
 /// Represents a musical key.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Key {
     /// ID of this row.
@@ -1429,6 +1468,7 @@ impl PageHeapObject for Key {
 /// Represents a record label.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Label {
     /// ID of this row.
@@ -1469,6 +1509,7 @@ impl PageHeapObject for Label {
 /// Represents a node in the playlist tree (either a folder or a playlist).
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct PlaylistTreeNode {
     /// ID of parent row of this row (which means that the parent is a folder).
@@ -1529,6 +1570,7 @@ impl PageHeapObject for PlaylistTreeNode {
 /// Represents a track entry in a playlist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct PlaylistEntry {
     /// Position within the playlist.
@@ -1573,6 +1615,7 @@ impl PageHeapObject for PlaylistEntry {
 /// on CDJs.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct ColumnEntry {
     // Possibly the primary key, though I don't know if that would
@@ -1623,6 +1666,7 @@ impl PageHeapObject for ColumnEntry {
 }
 
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 /// String fields stored via the offset table in Track rows
 pub struct TrackStrings {
     /// International Standard Recording Code (ISRC), in mangled format.
@@ -1732,6 +1776,7 @@ impl OffsetArrayItems<21> for TrackStrings {
 /// Contains the album name, along with an ID of the corresponding artist.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Track {
     /// Unknown field, usually `24 00`.
@@ -1865,6 +1910,7 @@ impl PageHeapObject for Track {
 /// Visibility state for a Menu on the CDJ.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub enum MenuVisibility {
     /// The menu is visible.
@@ -1887,6 +1933,7 @@ impl PageHeapObject for MenuVisibility {
 /// This table defines the active menus on the CDJ.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct Menu {
     /// Determines the Label (e.g. "ARTIST").
@@ -1952,6 +1999,7 @@ impl RowVariant for Menu {
 /// A table row contains the actual data.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(page_type: PlainPageType))]
 // The large enum size is unfortunate, but since users of this library will probably use iterators
@@ -2041,6 +2089,7 @@ impl PageHeapObject for PlainRow {
 /// A table row contains the actual data.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(page_type: PageType))]
 // The large enum size is unfortunate, but since users of this library will probably use iterators

--- a/src/pdb/offset_array.rs
+++ b/src/pdb/offset_array.rs
@@ -46,6 +46,8 @@
 use super::PageHeapObject;
 use crate::util::{ArrayPolyfills, MaybeCalculated};
 use binrw::{binrw, io::SeekFrom, BinRead, BinResult, BinWrite};
+#[cfg(feature = "json")]
+use serde::Serialize;
 
 /// Per-item alignment requirement when writing `OffsetArrayContainer` items with calculated offsets.
 pub trait OffsetArrayItemAlignment {
@@ -63,13 +65,13 @@ impl<const N: usize> OffsetArrayItemAlignment for [u8; N] {}
 
 /// Specifies whether the offsets are stored as u8 or u16.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum OffsetSize {
     /// Offsets are stored as u8.
     U8,
     /// Offsets are stored as u16.
     U16,
 }
-
 impl OffsetSize {
     fn bytes(&self) -> usize {
         match self {
@@ -82,6 +84,7 @@ impl OffsetSize {
 /// A container for an array of offsets and the indirectly-addressed data at those offsets.
 /// See the module documentation for an example.
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct OffsetArrayContainer<T, const N: usize> {
     /// The offsets, either u8 or u16.
     /// May be calculated from the inner data during serialization.
@@ -303,6 +306,19 @@ impl<const N: usize> PageHeapObject for OffsetArray<N> {
     type Args<'a> = OffsetSize;
     fn heap_bytes_required(&self, offset_size: OffsetSize) -> u16 {
         ((N + 1) * offset_size.bytes()) as u16
+    }
+}
+
+#[cfg(feature = "json")]
+impl<const N: usize> Serialize for OffsetArray<N> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            OffsetArray::U8(arr) => arr.as_slice().serialize(serializer),
+            OffsetArray::U16(arr) => arr.as_slice().serialize(serializer),
+        }
     }
 }
 

--- a/src/pdb/string.rs
+++ b/src/pdb/string.rs
@@ -14,6 +14,8 @@
 use super::PageHeapObject;
 use crate::pdb::offset_array::OffsetArrayItemAlignment;
 use binrw::binrw;
+#[cfg(feature = "json")]
+use serde::{Serialize, Serializer};
 use std::{convert::TryInto, fmt, str::FromStr};
 use thiserror::Error;
 
@@ -60,6 +62,17 @@ pub enum StringError {
 #[binrw]
 #[brw(little)]
 pub struct DeviceSQLString(DeviceSQLStringImpl);
+
+#[cfg(feature = "json")]
+impl Serialize for DeviceSQLString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 impl DeviceSQLString {
     /// Initializes a [`DeviceSQLString`] from a plain Rust [`std::string::String`]
     pub fn new(string: &str) -> Result<Self, StringError> {

--- a/src/setting.rs
+++ b/src/setting.rs
@@ -22,11 +22,24 @@
 //! The `SettingData` structs implement the `Default` trait and allows you to create objects that
 //! use the same default values as found in Rekordbox 6.6.1.
 
+#[cfg(feature = "json")]
+use crate::util::serialize_as_hex;
 use binrw::{binrw, io::Cursor, BinWrite, Endian, NullString};
 use parse_display::Display;
+#[cfg(feature = "json")]
+use serde::{Serialize, Serializer};
+
+#[cfg(feature = "json")]
+fn serialize_null_string<S>(ns: &NullString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&ns.to_string())
+}
 
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(setting_type: SettingType))]
 #[bw(import(no_checksum: bool))]
@@ -35,6 +48,7 @@ pub struct Setting {
     /// Size of the string data field (should be always 96).
     #[br(temp, assert(len_stringdata == 0x60))]
     #[bw(calc = 0x60)]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_stringdata: u32,
     /// Name of the brand.
     ///
@@ -47,17 +61,21 @@ pub struct Setting {
     /// | `MYSETTING.DAT`    | `PIONEER`    |
     /// | `MYSETTING2.DAT`   | `PIONEER`    |
     #[brw(pad_size_to = 0x20, assert(brand.len() <= (0x20 - 1)))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_null_string"))]
     pub brand: NullString,
     /// Name of the software ("rekordbox").
     #[brw(pad_size_to = 0x20, assert(software.len() <= (0x20 - 1)))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_null_string"))]
     pub software: NullString,
     /// Some kind of version number.
     #[brw(pad_size_to = 0x20, assert(version.len() <= (0x20 - 1)))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_null_string"))]
     pub version: NullString,
     /// Size of the `data` data in bytes.
     #[br(temp)]
     #[bw(calc = data.size())]
     #[br(assert(len_data == setting_type.expected_data_size()))]
+    #[cfg_attr(feature = "json", serde(skip))]
     len_data: u32,
     /// The actual settings data.
     #[br(args(setting_type))]
@@ -70,11 +88,13 @@ pub struct Setting {
     /// details.
     #[br(temp)]
     #[bw(calc = if no_checksum { 0 } else { self.calculate_checksum() })]
+    #[cfg_attr(feature = "json", serde(skip))]
     _checksum: u16,
     /// Unknown field (apparently always `0000`).
     #[br(temp)]
     #[br(assert(unknown == 0))]
     #[bw(calc = 0u16)]
+    #[cfg_attr(feature = "json", serde(skip))]
     unknown: u16,
 }
 
@@ -196,6 +216,7 @@ impl SettingType {
 /// Data section of a `*SETTING.DAT` file.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 #[br(import(setting_type: SettingType))]
 pub enum SettingData {
@@ -263,10 +284,12 @@ impl SettingData {
 /// Payload of a `DEVSETTING.DAT` file (32 bytes).
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct DevSetting {
     /// Unknown field.
     #[br(assert(unknown1 == [0x78, 0x56, 0x34, 0x12, 0x01, 0x00, 0x00, 0x00, 0x01]))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown1: [u8; 9],
     /// "Type of the overview Waveform" setting.
     pub overview_waveform_type: OverviewWaveformType,
@@ -281,6 +304,7 @@ pub struct DevSetting {
     pub waveform_current_position: WaveformCurrentPosition,
     /// Unknown field.
     #[br(assert(unknown3 == [0x00; 18]))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown3: [u8; 18],
 }
 
@@ -301,9 +325,11 @@ impl Default for DevSetting {
 /// Payload of a `DJMMYSETTING.DAT` file (52 bytes).
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct DJMMySetting {
     /// Unknown field.
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown1: [u8; 12],
     /// "CH FADER CURVE" setting.
     pub channel_fader_curve: ChannelFaderCurve,
@@ -333,6 +359,7 @@ pub struct DJMMySetting {
     pub channel_fader_curve_long_fader: ChannelFaderCurveLongFader,
     /// Unknown field (apparently always 0).
     #[br(assert(unknown2 == [0; 27]))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown2: [u8; 27],
 }
 
@@ -363,9 +390,11 @@ impl Default for DJMMySetting {
 /// Payload of a `MYSETTING.DAT` file (40 bytes).
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct MySetting {
     /// Unknown field.
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown1: [u8; 8],
     /// "ON AIR DISPLAY" setting.
     pub on_air_display: OnAirDisplay,
@@ -386,6 +415,7 @@ pub struct MySetting {
     /// "SLIP FLASHING" setting.
     pub slip_flashing: SlipFlashing,
     /// Unknown field.
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown3: [u8; 3],
     /// "DISC SLOT ILLUMINATION" setting.
     pub disc_slot_illumination: DiscSlotIllumination,
@@ -464,6 +494,7 @@ impl Default for MySetting {
 /// Payload of a `MYSETTING2.DAT` file (40 bytes).
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(little)]
 pub struct MySetting2 {
     /// "VINYL SPEED ADJUST" setting.
@@ -478,6 +509,7 @@ pub struct MySetting2 {
     pub waveform_divisions: WaveformDivisions,
     /// Unknown field (apparently always 0).
     #[br(assert(unknown1 == [0; 5]))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown1: [u8; 5],
     /// "WAVEFORM / PHASE METER" setting.
     pub waveform: Waveform,
@@ -487,6 +519,7 @@ pub struct MySetting2 {
     pub beat_jump_beat_value: BeatJumpBeatValue,
     /// Unknown field (apparently always 0).
     #[br(assert(unknown3 == [0; 27]))]
+    #[cfg_attr(feature = "json", serde(serialize_with = "serialize_as_hex"))]
     unknown3: [u8; 27],
 }
 
@@ -511,6 +544,7 @@ impl Default for MySetting2 {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum PlayMode {
     /// Named "CONTINUE / ON" in the Rekordbox preferences.
@@ -526,6 +560,7 @@ pub enum PlayMode {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum EjectLock {
     /// Named "UNLOCK" in the Rekordbox preferences.
@@ -539,6 +574,7 @@ pub enum EjectLock {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum NeedleLock {
     /// Named "UNLOCK" in the Rekordbox preferences.
@@ -552,6 +588,7 @@ pub enum NeedleLock {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum QuantizeBeatValue {
     /// Named "1/8 Beat" in the Rekordbox preferences.
@@ -573,6 +610,7 @@ pub enum QuantizeBeatValue {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum HotCueAutoLoad {
     /// Named "OFF" in the Rekordbox preferences.
@@ -589,6 +627,7 @@ pub enum HotCueAutoLoad {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum HotCueColor {
     /// Named "OFF" in the Rekordbox preferences.
@@ -602,6 +641,7 @@ pub enum HotCueColor {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum AutoCueLevel {
     /// Named "-78dB" in the Rekordbox preferences.
@@ -637,6 +677,7 @@ pub enum AutoCueLevel {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum TimeMode {
     /// Named "Elapsed" in the Rekordbox preferences.
@@ -650,6 +691,7 @@ pub enum TimeMode {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum AutoCue {
     /// Named "OFF" in the Rekordbox preferences.
@@ -663,6 +705,7 @@ pub enum AutoCue {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum JogMode {
     /// Named "VINYL" in the Rekordbox preferences.
@@ -676,6 +719,7 @@ pub enum JogMode {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum TempoRange {
     /// Named "±6" in the Rekordbox preferences.
@@ -696,6 +740,7 @@ pub enum TempoRange {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MasterTempo {
     /// Named "OFF" in the Rekordbox preferences.
@@ -709,6 +754,7 @@ pub enum MasterTempo {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum Quantize {
     /// Named "OFF" in the Rekordbox preferences.
@@ -722,6 +768,7 @@ pub enum Quantize {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum Sync {
     /// Named "OFF" in the Rekordbox preferences.
@@ -735,6 +782,7 @@ pub enum Sync {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum PhaseMeter {
     /// Named "TYPE 1" in the Rekordbox preferences.
@@ -750,6 +798,7 @@ pub enum PhaseMeter {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum Waveform {
     /// Named "WAVEFORM" in the Rekordbox preferences.
@@ -764,6 +813,7 @@ pub enum Waveform {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum WaveformDivisions {
     /// Named "TIME SCALE" in the Rekordbox preferences.
@@ -778,6 +828,7 @@ pub enum WaveformDivisions {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum VinylSpeedAdjust {
     /// Named "TOUCH & RELEASE" in the Rekordbox preferences.
@@ -794,6 +845,7 @@ pub enum VinylSpeedAdjust {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum BeatJumpBeatValue {
     /// Named "1/2 BEAT" in the Rekordbox preferences.
@@ -827,6 +879,7 @@ pub enum BeatJumpBeatValue {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum Language {
     /// Named "English" in the Rekordbox preferences.
@@ -889,6 +942,7 @@ pub enum Language {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum LCDBrightness {
     /// Named "1" in the Rekordbox preferences.
@@ -913,6 +967,7 @@ pub enum LCDBrightness {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum JogLCDBrightness {
     /// Named "1" in the Rekordbox preferences.
@@ -937,6 +992,7 @@ pub enum JogLCDBrightness {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum JogDisplayMode {
     /// Named "AUTO" in the Rekordbox preferences.
@@ -954,6 +1010,7 @@ pub enum JogDisplayMode {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum SlipFlashing {
     /// Named "OFF" in the Rekordbox preferences.
@@ -967,6 +1024,7 @@ pub enum SlipFlashing {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum OnAirDisplay {
     /// Named "OFF" in the Rekordbox preferences.
@@ -980,6 +1038,7 @@ pub enum OnAirDisplay {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum JogRingBrightness {
     /// Named "OFF" in the Rekordbox preferences.
@@ -997,6 +1056,7 @@ pub enum JogRingBrightness {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum JogRingIndicator {
     /// Named "OFF" in the Rekordbox preferences.
@@ -1010,6 +1070,7 @@ pub enum JogRingIndicator {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum DiscSlotIllumination {
     /// Named "OFF" in the Rekordbox preferences.
@@ -1027,6 +1088,7 @@ pub enum DiscSlotIllumination {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum PadButtonBrightness {
     /// Named "1" in the Rekordbox preferences.
@@ -1048,6 +1110,7 @@ pub enum PadButtonBrightness {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum ChannelFaderCurve {
     /// Steep volume raise when the fader is moved near the top.
@@ -1066,6 +1129,7 @@ pub enum ChannelFaderCurve {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum CrossfaderCurve {
     /// Logarithmic volume raise of the other channel near the edges of the fader.
@@ -1086,6 +1150,7 @@ pub enum CrossfaderCurve {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum ChannelFaderCurveLongFader {
     /// Very steep volume raise when the fader is moved the near the top (e.g. y = x⁵).
@@ -1101,6 +1166,7 @@ pub enum ChannelFaderCurveLongFader {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum HeadphonesPreEQ {
     /// Named "POST EQ" in the Rekordbox preferences.
@@ -1116,6 +1182,7 @@ pub enum HeadphonesPreEQ {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum HeadphonesMonoSplit {
     /// Named "MONO SPLIT" in the Rekordbox preferences.
@@ -1130,6 +1197,7 @@ pub enum HeadphonesMonoSplit {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum BeatFXQuantize {
     /// Named "OFF" in the Rekordbox preferences.
@@ -1143,6 +1211,7 @@ pub enum BeatFXQuantize {
 /// Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MicLowCut {
     /// Named "OFF" in the Rekordbox preferences.
@@ -1156,6 +1225,7 @@ pub enum MicLowCut {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum TalkOverMode {
     /// Named "ADVANCED" in the Rekordbox preferences.
@@ -1169,6 +1239,7 @@ pub enum TalkOverMode {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum TalkOverLevel {
     /// Named "-24dB" in the Rekordbox preferences.
@@ -1190,6 +1261,7 @@ pub enum TalkOverLevel {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MidiChannel {
     /// Named "1" in the Rekordbox preferences.
@@ -1247,6 +1319,7 @@ pub enum MidiChannel {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MidiButtonType {
     #[default]
@@ -1260,6 +1333,7 @@ pub enum MidiButtonType {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MixerDisplayBrightness {
     /// Named "WHITE" in the Rekordbox preferences.
@@ -1286,6 +1360,7 @@ pub enum MixerDisplayBrightness {
 /// preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum MixerIndicatorBrightness {
     /// Named "1" in the Rekordbox preferences.
@@ -1305,6 +1380,7 @@ pub enum MixerIndicatorBrightness {
 /// Found on the "General" page in the Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum WaveformColor {
     /// Named "BLUE" in the Rekordbox preferences.
@@ -1323,6 +1399,7 @@ pub enum WaveformColor {
 /// Found on the "General" page in the Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum WaveformCurrentPosition {
     /// Named "LEFT" in the Rekordbox preferences.
@@ -1337,6 +1414,7 @@ pub enum WaveformCurrentPosition {
 /// Found on the "General" page in the Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum OverviewWaveformType {
     /// Named "Half Waveform" in the Rekordbox preferences.
@@ -1353,6 +1431,7 @@ pub enum OverviewWaveformType {
 /// Found on the "General" page in the Rekordbox preferences.
 #[binrw]
 #[derive(Display, Debug, PartialEq, Eq, Default, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 #[brw(repr = u8)]
 pub enum KeyDisplayFormat {
     /// Named "Classic" in the Rekordbox preferences.

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,21 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use crate::pdb::string::StringError;
 use crate::pdb::{PageIndex, PageType};
 use binrw::{binrw, file_ptr::IntoSeekFrom, BinRead, BinResult, BinWrite, Endian};
+#[cfg(feature = "json")]
+use serde::{Serialize, Serializer};
 use thiserror::Error;
+
+/// Helper function to serialize a slice of bytes as a hex string.
+#[cfg(feature = "json")]
+pub fn serialize_as_hex<S>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut hex = String::with_capacity(2 + data.len() * 2);
+    hex.push_str("0x");
+    hex.push_str(&faster_hex::hex_string(data));
+    serializer.serialize_str(&hex)
+}
 
 /// Enumerates errors returned by this library.
 #[derive(Error, Debug)]
@@ -71,6 +85,7 @@ pub type RekordcrateResult<T> = std::result::Result<T, RekordcrateError>;
 /// Wrapper for types which may be automatically calculated if not
 /// provided by the user, or may be explicitly set when parsing existing data.
 #[derive(Debug, PartialEq, Clone, Eq)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum MaybeCalculated<T> {
     /// Value is calculated from some other value during serialization.
     Calculated,
@@ -91,6 +106,7 @@ impl From<usize> for TableIndex {
 /// Indexed Color identifiers used for memory cues and tracks.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum ColorIndex {
     /// No color.
     #[brw(magic = 0u8)]
@@ -124,6 +140,7 @@ pub enum ColorIndex {
 /// Track file type.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub enum FileType {
     /// Unknown file type.
     #[brw(magic = 0x0u16)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -77,6 +77,11 @@ pub enum RekordcrateError {
     #[cfg(feature = "xml")]
     #[error(transparent)]
     XmlDeserializationFailed(#[from] quick_xml::DeError),
+
+    /// Represents a `serde_json::Error` from serializing dump output.
+    #[cfg(feature = "json")]
+    #[error(transparent)]
+    JsonSerializationFailed(#[from] serde_json::Error),
 }
 
 /// Type alias for results where the error is a `RekordcrateError`.


### PR DESCRIPTION
when using the `dump-*` commands to inspect files, i found the `Debug` trait output a bit difficult to work with, so this adds JSON support to make it easier to read & inspect with tools like `jq`.

this is a bit opinionated in serializing byte slices as hex strings rather then arrays of `Number`, but i think this makes the output significantly easier to read & browse though.

some manual implementations of `Serialize`, like for `WaveformPreviewColumn`, are because the default serialization resulted in a hard to read format.

as an example, a settings dump in json format:

```json
{
  "brand": "PIONEER",
  "software": "rekordbox",
  "version": "0.001",
  "data": {
    "MySetting": {
      "unknown1": "0x7856341202000000",
      "on_air_display": "On",
      "lcd_brightness": "Two",
      "quantize": "On",
      "auto_cue_level": "Memory",
      "language": "English",
      "unknown2": 1,
      "jog_ring_brightness": "Bright",
      "jog_ring_indicator": "On",
      "slip_flashing": "On",
      "unknown3": "0x010101",
      "disc_slot_illumination": "Bright",
      "eject_lock": "Unlock",
      "sync": "Off",
      "play_mode": "Continue",
      "quantize_beat_value": "FullBeat",
      "hotcue_autoload": "On",
      "hotcue_color": "Off",
      "unknown4": 0,
      "needle_lock": "Lock",
      "unknown5": 0,
      "time_mode": "Remain",
      "jog_mode": "Vinyl",
      "auto_cue": "Off",
      "master_tempo": "On",
      "tempo_range": "TenPercent",
      "phase_meter": "Type2",
      "unknown6": 0
    }
  }
}
```