### PR TITLE
fix(pdb): align Ucs2le strings to 4 bytes

### DIFF
--- a/src/pdb/offset_array.rs
+++ b/src/pdb/offset_array.rs
@@ -47,6 +47,20 @@ use super::PageHeapObject;
 use crate::util::{ArrayPolyfills, MaybeCalculated};
 use binrw::{binrw, io::SeekFrom, BinRead, BinResult, BinWrite};
 
+/// Per-item alignment requirement when writing `OffsetArrayContainer` items with calculated offsets.
+pub trait OffsetArrayItemAlignment {
+    /// Required byte alignment of the item's start offset.
+    fn required_alignment(&self) -> u16 {
+        1
+    }
+}
+
+impl OffsetArrayItemAlignment for u8 {}
+impl OffsetArrayItemAlignment for u16 {}
+impl OffsetArrayItemAlignment for u32 {}
+impl OffsetArrayItemAlignment for () {}
+impl<const N: usize> OffsetArrayItemAlignment for [u8; N] {}
+
 /// Specifies whether the offsets are stored as u8 or u16.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OffsetSize {
@@ -112,6 +126,10 @@ impl<T, const N: usize> OffsetArrayContainer<T, N> {
                 message: format!("Stream position underflow: {start}-{offset}"),
             })
     }
+
+    fn aligned_offset(offset: u64, align: u16) -> u64 {
+        offset.next_multiple_of(u64::from(align.max(1)))
+    }
 }
 
 impl<T, U, const N: usize, IA> BinRead for OffsetArrayContainer<T, N>
@@ -155,7 +173,7 @@ where
 impl<T, U, const N: usize, IA> BinWrite for OffsetArrayContainer<T, N>
 where
     T: OffsetArrayItems<N, Item = U>,
-    U: for<'a> BinWrite<Args<'a> = IA>,
+    U: for<'a> BinWrite<Args<'a> = IA> + OffsetArrayItemAlignment,
     IA: Clone,
 {
     type Args<'a> = (u64, OffsetSize, IA);
@@ -174,7 +192,17 @@ where
                 let offsets_bytes = (N + 1) * offset_size.bytes();
                 writer.seek(SeekFrom::Current(offsets_bytes as i64))?;
                 let offsets_raw = items.try_map_polyfill(|v| {
-                    let offset = writer.stream_position()? - base;
+                    let current_offset = writer.stream_position()? - base;
+                    let aligned_offset =
+                        Self::aligned_offset(current_offset, v.required_alignment());
+                    let pad = aligned_offset - current_offset;
+                    if pad > 0 {
+                        for _ in 0..pad {
+                            writer.write_all(&[0u8])?;
+                        }
+                    }
+
+                    let offset = aligned_offset;
                     v.write_options(writer, endian, args.clone())?;
                     Ok::<_, binrw::Error>(offset)
                 })?;
@@ -214,18 +242,18 @@ where
 impl<T, U, const N: usize> PageHeapObject for OffsetArrayContainer<T, N>
 where
     T: OffsetArrayItems<N, Item = U> + 'static,
-    U: for<'a> PageHeapObject<Args<'a> = ()>,
+    U: for<'a> PageHeapObject<Args<'a> = ()> + OffsetArrayItemAlignment,
 {
     type Args<'a> = OffsetSize;
     fn heap_bytes_required(&self, offset_size: OffsetSize) -> u16 {
-        let offsets_bytes = (N + 1) * offset_size.bytes();
-        offsets_bytes as u16
-            + self
-                .inner
-                .as_items()
-                .into_iter()
-                .map(|item| item.heap_bytes_required(()))
-                .sum::<u16>()
+        let mut total = ((N + 1) * offset_size.bytes()) as u16;
+        for item in self.inner.as_items() {
+            if matches!(self.offsets, MaybeCalculated::Calculated) {
+                total = Self::aligned_offset(u64::from(total), item.required_alignment()) as u16;
+            }
+            total += item.heap_bytes_required(());
+        }
+        total
     }
 }
 
@@ -317,6 +345,7 @@ impl<const N: usize> From<[u16; N]> for OffsetArray<N> {
 mod test {
 
     use super::*;
+    use crate::pdb::string::DeviceSQLString;
     use crate::util::testing::{test_roundtrip_with_args, test_write};
     use crate::util::MaybeCalculated::*;
 
@@ -509,6 +538,24 @@ mod test {
         };
         test_write(
             &[0x03, 0x03, 0x04, 0xC0, 0xDE],
+            &multiple,
+            (0, OffsetSize::U8, ()),
+        );
+    }
+
+    #[test]
+    fn calculated_aligns_ucs2_item_to_4bytes() {
+        let multiple = OffsetArrayContainer {
+            offsets: Calculated,
+            inner: Multiple {
+                a: DeviceSQLString::new("foo").unwrap(),
+                b: DeviceSQLString::new("é").unwrap(),
+            },
+        };
+        test_write(
+            &[
+                0x03, 0x03, 0x08, 0x09, 0x66, 0x6F, 0x6F, 0x00, 0x90, 0x06, 0x00, 0x00, 0xE9, 0x00,
+            ],
             &multiple,
             (0, OffsetSize::U8, ()),
         );

--- a/src/pdb/string.rs
+++ b/src/pdb/string.rs
@@ -12,6 +12,7 @@
 //! See <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/exports.html#devicesql-strings>
 
 use super::PageHeapObject;
+use crate::pdb::offset_array::OffsetArrayItemAlignment;
 use binrw::binrw;
 use std::{convert::TryInto, fmt, str::FromStr};
 use thiserror::Error;
@@ -193,6 +194,17 @@ impl PageHeapObject for DeviceSQLString {
                     + (0u8).heap_bytes_required(())
                     + content.byte_count().unwrap()
             }
+        }
+    }
+}
+
+impl OffsetArrayItemAlignment for DeviceSQLString {
+    fn required_alignment(&self) -> u16 {
+        match &self.0 {
+            DeviceSQLStringImpl::Long {
+                content: LongBody::Ucs2le(_),
+            } => 4,
+            _ => 1,
         }
     }
 }


### PR DESCRIPTION
I had this lying around... My CDJ-350 players would instantly crash when reading a generated pdb export containing Ucs2le strings without this fix. Maybe someone has an intuition on a more general fix or better way to work around the issue. 