### PR TITLE
Extending the `device` API to create exports from scratch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +129,12 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
@@ -189,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +229,15 @@ name = "crc16"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "diff"
@@ -225,10 +258,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
 
 [[package]]
 name = "glob"
@@ -267,6 +329,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "modular-bitfield"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +419,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -374,6 +484,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "pretty-hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +520,18 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -456,6 +591,7 @@ dependencies = [
  "crc16",
  "fallible-iterator",
  "glob",
+ "image",
  "modular-bitfield",
  "parse-display",
  "pretty-hex",
@@ -528,6 +664,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "static_assertions"
@@ -667,6 +809,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,3 +952,18 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_repr = { version = "0.1.19", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
 rgb = { version = "0.8", optional = true }
 fallible-iterator = "0.3.0"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"], optional = true }
 
 [build-dependencies]
 glob = "0.3"
@@ -36,6 +37,7 @@ pretty_assertions = "1"
 default = ["cli", "xml"]
 cli = ["dep:clap"]
 xml = ["dep:serde", "dep:serde_repr", "dep:quick-xml", "dep:chrono", "dep:rgb"]
+artwork = ["dep:image"]
 
 [[bin]]
 name = "rekordcrate"

--- a/src/device/layout.rs
+++ b/src/device/layout.rs
@@ -23,9 +23,9 @@ pub const DAT_FILES: &[(&str, SettingType)] = &[
 
 /// On-disk layout of a device export rooted at `root`. Derives all paths from it on demand.
 ///
-/// Exposed so expert callers can locate [`Self::export_pdb`] and the surrounding `PIONEER` /
-/// `Contents` directories directly, for manual inspection or modification outside the high-level
-/// reader/writer.
+/// Exposed so expert callers can locate [`Self::export_pdb`] / [`Self::export_ext_pdb`] and the
+/// surrounding `PIONEER` / `Contents` directories directly, for manual inspection or modification
+/// outside the high-level reader/writer.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Layout {
     root: PathBuf,
@@ -68,6 +68,12 @@ impl Layout {
     #[must_use]
     pub fn export_pdb(&self) -> PathBuf {
         self.rekordbox_dir().join("export.pdb")
+    }
+
+    /// Path to `exportExt.pdb`.
+    #[must_use]
+    pub fn export_ext_pdb(&self) -> PathBuf {
+        self.rekordbox_dir().join("exportExt.pdb")
     }
 
     /// The `PIONEER/USBANLZ` directory holding per-track analysis files.

--- a/src/device/layout.rs
+++ b/src/device/layout.rs
@@ -14,7 +14,7 @@ use crate::setting::SettingType;
 use std::path::{Path, PathBuf};
 
 /// The `*SETTING.DAT` files in a device export, in the order Rekordbox writes them.
-pub(crate) const DAT_FILES: &[(&str, SettingType)] = &[
+pub const DAT_FILES: &[(&str, SettingType)] = &[
     ("DEVSETTING.DAT", SettingType::DevSetting),
     ("DJMMYSETTING.DAT", SettingType::DJMMySetting),
     ("MYSETTING.DAT", SettingType::MySetting),
@@ -22,65 +22,102 @@ pub(crate) const DAT_FILES: &[(&str, SettingType)] = &[
 ];
 
 /// On-disk layout of a device export rooted at `root`. Derives all paths from it on demand.
+///
+/// Exposed so expert callers can locate [`Self::export_pdb`] and the surrounding `PIONEER` /
+/// `Contents` directories directly, for manual inspection or modification outside the high-level
+/// reader/writer.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Layout {
+pub struct Layout {
     root: PathBuf,
 }
 
 impl Layout {
-    pub(crate) fn new(root: PathBuf) -> Self {
+    /// Wrap a device-export root directory.
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
         Self { root }
     }
 
-    pub(crate) fn root(&self) -> &Path {
+    /// The device root directory this layout was built from.
+    #[must_use]
+    pub fn root(&self) -> &Path {
         &self.root
     }
 
-    pub(crate) fn pioneer_dir(&self) -> PathBuf {
+    /// The `PIONEER` directory.
+    #[must_use]
+    pub fn pioneer_dir(&self) -> PathBuf {
         self.root.join("PIONEER")
     }
 
-    pub(crate) fn rekordbox_dir(&self) -> PathBuf {
+    /// The `PIONEER/rekordbox` directory holding the PDB files.
+    #[must_use]
+    pub fn rekordbox_dir(&self) -> PathBuf {
         self.pioneer_dir().join("rekordbox")
     }
 
-    pub(crate) fn export_pdb(&self) -> PathBuf {
+    /// Path to `export.pdb`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rekordcrate::device::layout::Layout;
+    /// let layout = Layout::new("/srv/export".into());
+    /// assert!(layout.export_pdb().ends_with("export.pdb"));
+    /// ```
+    #[must_use]
+    pub fn export_pdb(&self) -> PathBuf {
         self.rekordbox_dir().join("export.pdb")
     }
 
-    pub(crate) fn usbanlz_dir(&self) -> PathBuf {
+    /// The `PIONEER/USBANLZ` directory holding per-track analysis files.
+    #[must_use]
+    pub fn usbanlz_dir(&self) -> PathBuf {
         self.pioneer_dir().join("USBANLZ")
     }
 
-    pub(crate) fn contents_dir(&self) -> PathBuf {
+    /// The `Contents` directory holding audio files.
+    #[must_use]
+    pub fn contents_dir(&self) -> PathBuf {
         self.root.join("Contents")
     }
 
-    pub(crate) fn dat_path(&self, filename: &str) -> PathBuf {
+    /// Path to a `*SETTING.DAT` file by name, under `PIONEER`.
+    #[must_use]
+    pub fn dat_path(&self, filename: &str) -> PathBuf {
         self.pioneer_dir().join(filename)
     }
 
+    /// The `PIONEER/Artwork` directory (under the `artwork` feature).
     #[cfg(feature = "artwork")]
-    pub(crate) fn artwork_dir(&self) -> PathBuf {
+    #[must_use]
+    pub fn artwork_dir(&self) -> PathBuf {
         self.pioneer_dir().join("Artwork")
     }
 
+    /// Path to the 80×80 thumbnail `a{id}.jpg` (under the `artwork` feature).
     #[cfg(feature = "artwork")]
-    pub(crate) fn artwork_file(&self, id: u32) -> PathBuf {
+    #[must_use]
+    pub fn artwork_file(&self, id: u32) -> PathBuf {
         self.artwork_dir()
             .join(artwork_folder(id))
             .join(format!("a{id}.jpg"))
     }
 
+    /// Path to the 240×240 `a{id}_m.jpg` (under the `artwork` feature).
     #[cfg(feature = "artwork")]
-    pub(crate) fn artwork_m_file(&self, id: u32) -> PathBuf {
+    #[must_use]
+    pub fn artwork_m_file(&self, id: u32) -> PathBuf {
         self.artwork_dir()
             .join(artwork_folder(id))
             .join(format!("a{id}_m.jpg"))
     }
 }
 
+/// Five-digit shard folder name for artwork `id`: `id/20 + 1`, zero-padded (under the `artwork`
+/// feature).
 #[cfg(feature = "artwork")]
-pub(crate) fn artwork_folder(id: u32) -> String {
+#[must_use]
+pub fn artwork_folder(id: u32) -> String {
     format!("{:05}", id / 20 + 1)
 }

--- a/src/device/layout.rs
+++ b/src/device/layout.rs
@@ -6,9 +6,10 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! On-disk layout of a Rekordbox device export: where `export.pdb`, the `*SETTING.DAT` files,
-//! and the `PIONEER`/`USBANLZ`/`Contents` directories live relative to the device root. Shared by
-//! [`crate::device::DeviceExportReader`] and [`crate::device::DeviceExportWriter`].
+//! On-disk layout of a Rekordbox device export: where `export.pdb`, `exportExt.pdb`, the
+//! `SETTING.DAT` files and the `PIONEER`/`USBANLZ`/`Contents` directories live relative
+//! to the device root. Shared by [`crate::device::DeviceExportReader`] and
+//! [`crate::device::DeviceExportWriter`].
 
 use crate::setting::SettingType;
 use std::path::{Path, PathBuf};
@@ -120,9 +121,9 @@ impl Layout {
     }
 }
 
-/// Five-digit shard folder name for artwork `id`: `id/20 + 1`, zero-padded (under the `artwork`
-/// feature).
-#[cfg(feature = "artwork")]
+/// Five-digit shard folder name for artwork `id`: `id/20 + 1`, zero-padded. This is compiled even
+/// without the `artwork` feature, as the only thing the feature enables is converting and copying
+/// artwork files to their destination.
 #[must_use]
 pub fn artwork_folder(id: u32) -> String {
     format!("{:05}", id / 20 + 1)

--- a/src/device/layout.rs
+++ b/src/device/layout.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+// of the MPL was not distributed with this file, You can obtain one at
+// http://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! On-disk layout of a Rekordbox device export: where `export.pdb`, the `*SETTING.DAT` files,
+//! and the `PIONEER`/`USBANLZ`/`Contents` directories live relative to the device root. Shared by
+//! [`crate::device::DeviceExportReader`] and [`crate::device::DeviceExportWriter`].
+
+use crate::setting::SettingType;
+use std::path::{Path, PathBuf};
+
+/// The `*SETTING.DAT` files in a device export, in the order Rekordbox writes them.
+pub(crate) const DAT_FILES: &[(&str, SettingType)] = &[
+    ("DEVSETTING.DAT", SettingType::DevSetting),
+    ("DJMMYSETTING.DAT", SettingType::DJMMySetting),
+    ("MYSETTING.DAT", SettingType::MySetting),
+    ("MYSETTING2.DAT", SettingType::MySetting2),
+];
+
+/// On-disk layout of a device export rooted at `root`. Derives all paths from it on demand.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Layout {
+    root: PathBuf,
+}
+
+impl Layout {
+    pub(crate) fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub(crate) fn pioneer_dir(&self) -> PathBuf {
+        self.root.join("PIONEER")
+    }
+
+    pub(crate) fn rekordbox_dir(&self) -> PathBuf {
+        self.pioneer_dir().join("rekordbox")
+    }
+
+    pub(crate) fn export_pdb(&self) -> PathBuf {
+        self.rekordbox_dir().join("export.pdb")
+    }
+
+    pub(crate) fn dat_path(&self, filename: &str) -> PathBuf {
+        self.pioneer_dir().join(filename)
+    }
+}

--- a/src/device/layout.rs
+++ b/src/device/layout.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
+// Copyright (c) 2026 Jan Holthaus <jan.holthuis@rub.de>
 //
 // This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
 // of the MPL was not distributed with this file, You can obtain one at
@@ -48,7 +48,39 @@ impl Layout {
         self.rekordbox_dir().join("export.pdb")
     }
 
+    pub(crate) fn usbanlz_dir(&self) -> PathBuf {
+        self.pioneer_dir().join("USBANLZ")
+    }
+
+    pub(crate) fn contents_dir(&self) -> PathBuf {
+        self.root.join("Contents")
+    }
+
     pub(crate) fn dat_path(&self, filename: &str) -> PathBuf {
         self.pioneer_dir().join(filename)
     }
+
+    #[cfg(feature = "artwork")]
+    pub(crate) fn artwork_dir(&self) -> PathBuf {
+        self.pioneer_dir().join("Artwork")
+    }
+
+    #[cfg(feature = "artwork")]
+    pub(crate) fn artwork_file(&self, id: u32) -> PathBuf {
+        self.artwork_dir()
+            .join(artwork_folder(id))
+            .join(format!("a{id}.jpg"))
+    }
+
+    #[cfg(feature = "artwork")]
+    pub(crate) fn artwork_m_file(&self, id: u32) -> PathBuf {
+        self.artwork_dir()
+            .join(artwork_folder(id))
+            .join(format!("a{id}_m.jpg"))
+    }
+}
+
+#[cfg(feature = "artwork")]
+pub(crate) fn artwork_folder(id: u32) -> String {
+    format!("{:05}", id / 20 + 1)
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -19,6 +19,6 @@ pub mod reader;
 pub mod writer;
 
 pub use crate::device::reader::DeviceExportReader;
-pub use crate::device::writer::{AddTrackOutcome, DeviceExportWriter, Track};
+pub use crate::device::writer::{AddTrackOutcome, DeviceExportWriter, TagCategoryId, Track};
 
 pub use crate::device::reader::{get_playlists, Playlist, PlaylistFolder, PlaylistNode};

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -7,12 +7,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! High-level API for Rekordbox device exports.
-//!
-//! A device export is a directory tree holding `PIONEER/` (the `*SETTING.DAT` files and
-//! `rekordbox/export.pdb`), `PIONEER/USBANLZ/` (per-track analysis files), and `Contents/` (audio
-//! files). The shared on-disk layout lives in [`layout`].
-//!
-//! [`DeviceExportReader`] inspects an existing export; [`DeviceExportWriter`] builds one from scratch.
 
 pub mod layout;
 pub mod reader;

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+// of the MPL was not distributed with this file, You can obtain one at
+// http://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! High-level API for Rekordbox device exports.
+//!
+//! A device export is a directory tree holding `PIONEER/` (the `*SETTING.DAT` files and
+//! `rekordbox/export.pdb`), `PIONEER/USBANLZ/` (per-track analysis files), and `Contents/` (audio
+//! files). The shared on-disk layout lives in [`layout`].
+//!
+//! [`DeviceExportReader`] inspects an existing export.
+
+pub mod layout;
+pub mod reader;
+
+pub use crate::device::reader::DeviceExportReader;
+pub use crate::device::reader::{get_playlists, Playlist, PlaylistFolder, PlaylistNode};

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -12,10 +12,13 @@
 //! `rekordbox/export.pdb`), `PIONEER/USBANLZ/` (per-track analysis files), and `Contents/` (audio
 //! files). The shared on-disk layout lives in [`layout`].
 //!
-//! [`DeviceExportReader`] inspects an existing export.
+//! [`DeviceExportReader`] inspects an existing export; [`DeviceExportWriter`] builds one from scratch.
 
 pub mod layout;
 pub mod reader;
+pub mod writer;
 
 pub use crate::device::reader::DeviceExportReader;
+pub use crate::device::writer::{AddTrackOutcome, DeviceExportWriter, Track};
+
 pub use crate::device::reader::{get_playlists, Playlist, PlaylistFolder, PlaylistNode};

--- a/src/device/reader.rs
+++ b/src/device/reader.rs
@@ -6,14 +6,14 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! High-level API for working with Rekordbox device exports.
+//! Read-side access to a Rekordbox device export: a thin handle that exposes the setting files
+//! and the PDB database. See [`crate::device::layout`].
 
-use crate::{
-    pdb::io::Database,
-    pdb::{DatabaseType, PlaylistTreeNode, PlaylistTreeNodeId},
-    setting,
-    setting::{Setting, SettingType},
-};
+use crate::device::layout::{Layout, DAT_FILES};
+use crate::pdb::io::Database;
+use crate::pdb::{DatabaseType, PlaylistTreeNode, PlaylistTreeNodeId};
+use crate::setting;
+use crate::setting::{Setting, SettingType};
 use binrw::BinRead;
 use fallible_iterator::FallibleIterator;
 use std::collections::HashMap;
@@ -21,39 +21,34 @@ use std::fmt;
 use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 
-/// Represents a Rekordbox device export.
+/// A read-side handle to a Rekordbox device export on disk.
 #[derive(Debug, PartialEq)]
-pub struct DeviceExportLoader(PathBuf);
+pub struct DeviceExportReader(Layout);
 
-impl DeviceExportLoader {
-    /// Load device export from the given path.
-    ///
-    /// The path should contain a `PIONEER` directory.
+impl DeviceExportReader {
+    /// Point a reader at a device export on disk (a directory containing `PIONEER`).
     #[must_use]
     pub fn new(path: PathBuf) -> Self {
-        Self(path)
+        Self(Layout::new(path))
     }
 
-    /// Get the device path.
+    /// The device root path.
     #[must_use]
     pub fn get_path(&self) -> &Path {
-        &self.0
+        self.0.root()
     }
 
-    fn read_setting_file(path: &PathBuf, setting_type: SettingType) -> crate::Result<Setting> {
+    fn read_setting_file(path: &Path, setting_type: SettingType) -> crate::Result<Setting> {
         let mut reader = std::fs::File::open(path)?;
         let setting = Setting::read_args(&mut reader, (setting_type,))?;
         Ok(setting)
     }
 
-    /// Load setting files. If a file is missing or cannot be read,
-    /// a warning will be printed.
+    /// Load setting files. A missing or unreadable file is printed as a warning and skipped.
     #[must_use]
     pub fn load_settings(&self) -> Settings {
-        let path = self.0.join("PIONEER");
-
         let load_setting = |filename: &str, setting_type: SettingType| -> Option<Setting> {
-            let file_path = path.join(filename);
+            let file_path = self.0.dat_path(filename);
             match Self::read_setting_file(&file_path, setting_type) {
                 Ok(setting) => Some(setting),
                 Err(e) => {
@@ -64,27 +59,40 @@ impl DeviceExportLoader {
         };
 
         let mut settings = Settings::default();
-        if let Some(devsetting) = load_setting("DEVSETTING.DAT", SettingType::DevSetting) {
-            settings.set_devsetting(devsetting.data.as_dev_setting().unwrap());
-        }
-        if let Some(djmmysetting) = load_setting("DJMMYSETTING.DAT", SettingType::DJMMySetting) {
-            settings.set_djmmysetting(djmmysetting.data.as_djm_my_setting().unwrap());
-        }
-        if let Some(mysetting) = load_setting("MYSETTING.DAT", SettingType::MySetting) {
-            settings.set_mysetting(mysetting.data.as_my_setting().unwrap());
-        }
-        if let Some(mysetting2) = load_setting("MYSETTING2.DAT", SettingType::MySetting2) {
-            settings.set_mysetting2(mysetting2.data.as_my_setting2().unwrap());
+        for &(filename, setting_type) in DAT_FILES {
+            match setting_type {
+                SettingType::DevSetting => {
+                    if let Some(devsetting) = load_setting(filename, setting_type) {
+                        settings.set_devsetting(devsetting.data.as_dev_setting().unwrap());
+                    }
+                }
+                SettingType::DJMMySetting => {
+                    if let Some(djmmysetting) = load_setting(filename, setting_type) {
+                        settings.set_djmmysetting(djmmysetting.data.as_djm_my_setting().unwrap());
+                    }
+                }
+                SettingType::MySetting => {
+                    if let Some(mysetting) = load_setting(filename, setting_type) {
+                        settings.set_mysetting(mysetting.data.as_my_setting().unwrap());
+                    }
+                }
+                SettingType::MySetting2 => {
+                    if let Some(mysetting2) = load_setting(filename, setting_type) {
+                        settings.set_mysetting2(mysetting2.data.as_my_setting2().unwrap());
+                    }
+                }
+            }
         }
 
         settings
     }
 
-    /// Open a PDB database without persistence back to disk.
-    /// Still allows modifying data in memory.
+    /// Open the PDB database in memory (changes are not written back to disk).
     pub fn open_pdb_non_persistent(&self) -> crate::Result<Database<std::fs::File>> {
-        let path = self.0.join("PIONEER").join("rekordbox").join("export.pdb");
-        Database::open_non_persistent(std::fs::File::open(path)?, DatabaseType::Plain)
+        Database::open_non_persistent(
+            std::fs::File::open(self.0.export_pdb())?,
+            DatabaseType::Plain,
+        )
     }
 }
 
@@ -492,16 +500,16 @@ impl fmt::Display for Settings {
     }
 }
 
-/// Represents either a playlist folder or a playlist.
+/// Either a playlist folder or a playlist.
 #[derive(Debug, PartialEq)]
 pub enum PlaylistNode {
-    /// Represents a playlist folder that contains `PlaylistNode`s.
+    /// A folder containing child [`PlaylistNode`]s.
     Folder(PlaylistFolder),
-    /// Represents a playlist.
+    /// A playlist (leaf).
     Playlist(Playlist),
 }
 
-/// Represents a playlist folder that contains `PlaylistNode`s.
+/// A playlist folder.
 #[derive(Debug, PartialEq)]
 pub struct PlaylistFolder {
     /// ID of this node in the playlist tree.
@@ -512,7 +520,7 @@ pub struct PlaylistFolder {
     pub children: Vec<PlaylistNode>,
 }
 
-/// Represents a playlist.
+/// A playlist.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Playlist {
     /// ID of this node in the playlist tree.
@@ -521,7 +529,7 @@ pub struct Playlist {
     pub name: String,
 }
 
-/// Get playlist tree.
+/// Build the playlist tree from the PDB database.
 pub fn get_playlists<R: Read + Seek>(db: &mut Database<R>) -> crate::Result<Vec<PlaylistNode>> {
     let mut playlists: HashMap<PlaylistTreeNodeId, Vec<PlaylistTreeNode>> = HashMap::new();
 

--- a/src/device/reader.rs
+++ b/src/device/reader.rs
@@ -7,7 +7,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Read-side access to a Rekordbox device export: a thin handle that exposes the setting files
-//! and the PDB database. See [`crate::device::layout`].
+//! and the PDB database.
+//!
+//! See [`crate::device::layout`].
 
 use crate::device::layout::{Layout, DAT_FILES};
 use crate::pdb::io::Database;

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -404,8 +404,10 @@ impl DeviceExportWriter {
 
     /// Open an existing device export at the given path.
     ///
-    /// Opens the existing PDB database and scans for the highest IDs in each
-    /// table category to continue adding rows with non-conflicting IDs.
+    /// Opens the existing PDB database and scans for the highest IDs in each table category to
+    /// continue adding rows with non-conflicting IDs. Tag categories/leaves are recovered from
+    /// `exportExt.pdb` the same way (appending to it on later tag calls); if that file is absent
+    /// it is created lazily on the first tag call, as in [`create`](Self::create).
     ///
     /// # Errors
     ///
@@ -510,10 +512,38 @@ impl DeviceExportWriter {
             Ok(())
         })?;
 
+        // Recover tag state from the ext PDB so later tag calls append instead of truncating it.
+        // If the file is absent (no tags were ever written), the maps stay empty and `ext_db`
+        // stays `None`, so the first tag call creates it fresh — same as `create()`.
+        let mut tag_categories = HashSet::new();
+        let mut tags_by_key = HashMap::new();
+        let mut tag_leaf_counts = HashMap::new();
+        let mut next_category_position = 0u32;
+        let mut next_tag_id = 1u32;
+        let mut next_tag_row_index = 0u32;
+        let ext_db = if layout.export_ext_pdb().exists() {
+            let ext_file = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(layout.export_ext_pdb())?;
+            let mut ext_db = Database::open(ext_file, DatabaseType::Ext)?;
+            scan_ext_tags(
+                &mut ext_db,
+                &mut tag_categories,
+                &mut tags_by_key,
+                &mut tag_leaf_counts,
+                &mut next_category_position,
+                &mut next_tag_id,
+                &mut next_tag_row_index,
+            )?;
+            Some(ext_db)
+        } else {
+            None
+        };
+
         Ok(Self {
             db: Some(db),
-            // ext PDB is never read back by `open()` — any tags a prior session wrote are lost.
-            ext_db: None,
+            ext_db,
             layout,
             next_track_id,
             next_artist_id,
@@ -524,9 +554,9 @@ impl DeviceExportWriter {
             #[cfg(feature = "artwork")]
             next_artwork_id,
             next_playlist_node_id,
-            next_tag_id: 1,
-            next_category_position: 0,
-            next_tag_row_index: 0,
+            next_tag_id,
+            next_category_position,
+            next_tag_row_index,
             track_ids,
             playlist_nodes,
             tracks_by_path,
@@ -536,9 +566,9 @@ impl DeviceExportWriter {
             genres_by_name,
             keys_by_canonical,
             labels_by_name,
-            tag_categories: HashSet::new(),
-            tags_by_key: HashMap::new(),
-            tag_leaf_counts: HashMap::new(),
+            tag_categories,
+            tags_by_key,
+            tag_leaf_counts,
             #[cfg(feature = "artwork")]
             artwork_by_path,
         })
@@ -860,7 +890,7 @@ impl DeviceExportWriter {
 
         let row_index = self.next_tag_row_index;
         self.next_tag_row_index += 1;
-        self.ext_db_mut().add_row(Row::Ext(ExtRow::Tag(tag_row(
+        self.ext_db_mut()?.add_row(Row::Ext(ExtRow::Tag(tag_row(
             ParentId(None),
             position,
             TagId(id),
@@ -913,7 +943,7 @@ impl DeviceExportWriter {
 
         for label in non_empty {
             let tag_id = self.get_or_create_tag(category, label)?;
-            self.ext_db_mut()
+            self.ext_db_mut()?
                 .add_row(Row::Ext(ExtRow::TrackTag(TrackTag {
                     track_id,
                     tag_id: TagId(tag_id),
@@ -938,7 +968,7 @@ impl DeviceExportWriter {
 
         let row_index = self.next_tag_row_index;
         self.next_tag_row_index += 1;
-        self.ext_db_mut().add_row(Row::Ext(ExtRow::Tag(tag_row(
+        self.ext_db_mut()?.add_row(Row::Ext(ExtRow::Tag(tag_row(
             ParentId(NonZero::new(category.0)),
             position,
             TagId(id),
@@ -951,27 +981,26 @@ impl DeviceExportWriter {
         Ok(id)
     }
 
-    fn ext_db_mut(&mut self) -> &mut Database<fs::File> {
+    fn ext_db_mut(&mut self) -> Result<&mut Database<fs::File>> {
         if self.ext_db.is_none() {
             let ext_path = self.layout.export_ext_pdb();
             if let Some(parent) = ext_path.parent() {
                 let _ = fs::create_dir_all(parent);
             }
-            // panic on IO failure. Returning Result from every tag call would add a `?`
-            // to the hot path for a failure (unwritable device) that surfaces loudly a few lines
-            // later anyway. Revisit if a caller needs graceful handling.
-            let file = fs::File::create(&ext_path).expect("can create exportExt.pdb");
+            // Reached only when the file did not exist at `open()` time (or after `create()`), so
+            // truncation cannot destroy prior tags — `open()` would otherwise have opened it.
+            let file = fs::File::create(&ext_path)?;
             let table_page_types = [
                 PageType::Ext(ExtPageType::Tag),
                 PageType::Ext(ExtPageType::TrackTag),
             ];
-            let ext_db = Database::create(file, DatabaseType::Ext, &table_page_types)
-                .expect("can create ext PDB");
+            let ext_db = Database::create(file, DatabaseType::Ext, &table_page_types)?;
             self.ext_db = Some(ext_db);
         }
-        self.ext_db
+        Ok(self
+            .ext_db
             .as_mut()
-            .expect("ext_db was just initialized above")
+            .expect("ext_db was just initialized above"))
     }
 
     /// Flush pending writes and close the PDB. Prefer this over relying on `Drop`, which can't
@@ -1214,6 +1243,48 @@ impl DeviceExportWriter {
 
         Ok(())
     }
+}
+
+/// Walk the Tag rows of an existing ext PDB and rebuild the writer's in-memory tag state so later
+/// tag calls append without id/row-index collision or truncating prior rows. Mirrors the manual
+/// page walk in the tag tests because `TagOrCategory` does not implement `RowVariant`.
+///
+/// TrackTag junction rows carry no state the writer tracks (their ids reference tag rows already
+/// counted here), so they are not scanned.
+fn scan_ext_tags(
+    ext_db: &mut Database<fs::File>,
+    tag_categories: &mut HashSet<u32>,
+    tags_by_key: &mut HashMap<(u32, String), u32>,
+    tag_leaf_counts: &mut HashMap<u32, u32>,
+    next_category_position: &mut u32,
+    next_tag_id: &mut u32,
+    next_tag_row_index: &mut u32,
+) -> Result<()> {
+    let mut pages = ext_db.iter_pages(PageType::Ext(ExtPageType::Tag))?;
+    while let Some(page) = pages.next()? {
+        let Some(data) = page.content.as_data() else {
+            continue;
+        };
+        for row in data.rows.values() {
+            let Row::Ext(ExtRow::Tag(t)) = row else {
+                continue;
+            };
+            *next_tag_id = (*next_tag_id).max(t.id.0 + 1);
+            *next_tag_row_index = (*next_tag_row_index).max(u32::from(t.index_shift) / 0x20 + 1);
+            let parent = t.parent_id.0.map(NonZero::get).unwrap_or(0);
+            if t.raw_is_category != 0 {
+                tag_categories.insert(t.id.0);
+                *next_category_position = (*next_category_position).max(t.position + 1);
+            } else {
+                if let Ok(name) = t.offsets.inner.name.clone().into_string() {
+                    tags_by_key.entry((parent, name)).or_insert(t.id.0);
+                }
+                let count = tag_leaf_counts.entry(parent).or_insert(0);
+                *count = (*count).max(t.position + 1);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn write_setting_file(path: &Path, setting: &Setting) -> Result<()> {
@@ -2047,6 +2118,88 @@ mod tests {
         // Only the category row; no leaves, no junctions.
         assert_eq!(tags.len(), 1);
         assert_eq!(track_tags.len(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // open() must not truncate exportExt.pdb: prior categories/leaves/junctions survive, and later
+    // tag calls append with fresh ids and row indices (no collision).
+    #[test]
+    fn open_preserves_existing_tags() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-open-preserve-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let t = Track {
+            title: "a".into(),
+            filename: "a.mp3".into(),
+            file_path: "/Contents/a.mp3".into(),
+            ..Default::default()
+        };
+        let id = dev.add_track(&t).unwrap().id;
+        let cat = dev.create_tag_category("My Tags").unwrap();
+        dev.add_tags_to_track(id, cat, &["Techno".into(), "Dub".into()])
+            .unwrap();
+        dev.close().unwrap();
+
+        // Reopen and append a new leaf under the existing category plus a brand-new category.
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        dev.add_tags_to_track(id, cat, &["House".into()]).unwrap();
+        let cat2 = dev.create_tag_category("Mood").unwrap();
+        dev.add_tags_to_track(id, cat2, &["Dark".into()]).unwrap();
+        dev.close().unwrap();
+
+        let mut ext_db = Database::open(
+            std::fs::File::open(dir.join("PIONEER/rekordbox/exportExt.pdb")).unwrap(),
+            DatabaseType::Ext,
+        )
+        .unwrap();
+        let (tags, track_tags) = collect_ext_rows(&mut ext_db);
+
+        // Two categories (My Tags, Mood), no duplicates.
+        let categories: Vec<_> = tags.iter().filter(|t| t.raw_is_category != 0).collect();
+        assert_eq!(categories.len(), 2, "both categories must survive open()");
+        let cat_names: Vec<String> = categories
+            .iter()
+            .map(|t| t.offsets.inner.name.clone().into_string().unwrap())
+            .collect();
+        assert!(cat_names.iter().any(|n| n == "My Tags"));
+        assert!(cat_names.iter().any(|n| n == "Mood"));
+
+        // The three original leaves plus the two new ones (House, Dark); the pre-existing "Techno"
+        // and "Dub" must not have been duplicated.
+        let leaves: Vec<String> = tags
+            .iter()
+            .filter(|t| t.raw_is_category == 0)
+            .map(|t| t.offsets.inner.name.clone().into_string().unwrap())
+            .collect();
+        for expected in &["Techno", "Dub", "House", "Dark"] {
+            assert_eq!(
+                leaves.iter().filter(|n| *n == expected).count(),
+                1,
+                "leaf {expected:?} must appear exactly once, got {leaves:?}"
+            );
+        }
+
+        // TrackTag junctions: 2 from the first session + 1 (House) + 1 (Dark) = 4.
+        assert_eq!(track_tags.len(), 4);
+
+        // No two Tag rows share an id or an index_shift (would mean a counter wasn't recovered).
+        let mut ids: Vec<u32> = tags.iter().map(|t| t.id.0).collect();
+        ids.sort_unstable();
+        let id_dupes = ids.windows(2).any(|w| w[0] == w[1]);
+        assert!(!id_dupes, "tag ids collided after open(): {ids:?}");
+        let mut shifts: Vec<u16> = tags.iter().map(|t| t.index_shift).collect();
+        shifts.sort_unstable();
+        shifts.dedup();
+        assert_eq!(
+            shifts.len(),
+            tags.len(),
+            "index_shift values must be unique, got {shifts:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -1,0 +1,1562 @@
+// Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+// of the MPL was not distributed with this file, You can obtain one at
+// http://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Builds a Rekordbox USB export: the PDB database (`export.pdb`), the `PIONEER/*.DAT` setting
+//! files, and the `PIONEER`/`PIONEER/USBANLZ`/`Contents` directory layout.
+//!
+//! With the `artwork` feature enabled, it also copies each track's [`Track::artwork_path`] into
+//! `PIONEER/Artwork/{folder}/`, resizing to the 80×80 thumbnail (`a{id}.jpg`) and the 240×240
+//! medium (`a{id}_m.jpg`) that newer Rekordbox versions expect. Without the feature, artwork is a
+//! no-op: a raw copy of an unknown format/size can't be guaranteed CDJ-readable, so nothing is
+//! written. It never copies audio files into `Contents` or generates `PIONEER/USBANLZ` analysis
+//! files (`ANLZ.*`). The API is append-only — existing rows cannot be updated or deleted; re-add
+//! via a fresh export instead.
+//! TODO(acrilique): maybe we should make all pdb structs and fields public for now as a workaround
+
+#[cfg(feature = "artwork")]
+use crate::device::layout::artwork_folder;
+use crate::device::layout::{Layout, DAT_FILES};
+use crate::pdb::io::Database;
+use crate::pdb::offset_array::OffsetArrayContainer;
+use crate::pdb::string::DeviceSQLString;
+#[cfg(feature = "artwork")]
+use crate::pdb::Artwork;
+use crate::pdb::{
+    AlbumId, ArtistId, ArtworkId, DatabaseType, GenreId, KeyId, LabelId, PageType, PlainPageType,
+    PlainRow, PlaylistEntry, PlaylistTreeNode, PlaylistTreeNodeId, Row, TrackId,
+};
+use crate::setting::{Setting, SettingType};
+use crate::util::{ColorIndex, FileType, MaybeCalculated};
+use crate::{Error, Result};
+use binrw::BinWrite;
+use fallible_iterator::FallibleIterator;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io::Cursor;
+use std::path::Path;
+
+/// Re-export of [`crate::util::ForeignKeyKind`], for callers reaching it via this module.
+pub use crate::util::ForeignKeyKind;
+
+/// A track as a user thinks of it: plain `String` fields, no foreign-key IDs. Input to
+/// [`crate::DeviceExportWriter::add_track`], which resolves artists/albums/genres/keys/labels/artwork
+/// into deduplicated PDB rows and handles format quirks (the 221-byte minimum row size, centi-BPM
+/// tempo). Experts needing fields not exposed here should drive a `pdb::Track` row directly via
+/// [`crate::pdb::io::Database`].
+///
+/// `rating` is a raw byte passed straight through to the PDB. Rekordbox's encoding is unknown;
+/// Pioneer's XML spec documents `0/51/102/153/204/255` for 0–5 stars, but we have not confirmed the
+/// PDB uses the same mapping.
+/// TODO: confirm the PDB rating encoding against real hardware, then encode 0–5 stars internally.
+#[derive(Debug, Clone)]
+pub struct Track {
+    /// Track title.
+    pub title: String,
+    /// Performing artist name.
+    pub artist: String,
+    /// Album name.
+    pub album: String,
+    /// Genre name.
+    pub genre: String,
+    /// Musical key name (e.g. "Cmaj", "D\u{266d}min"). Folded to a canonical form for dedup.
+    pub key: String,
+    /// Record label name.
+    pub label: String,
+    /// Composer name.
+    pub composer: String,
+    /// Remixer name.
+    pub remixer: String,
+    /// Original performer, distinct from `artist` (covers/reworks).
+    pub orig_artist: String,
+    /// Free-text comment; also the auto-pad target when the row falls under the 221-byte minimum.
+    pub comment: String,
+    /// ISRC, in rekordbox's mangled format.
+    pub isrc: String,
+    /// Lyricist name.
+    pub lyricist: String,
+    /// Remix/mix name.
+    pub mix_name: String,
+    /// Free text (commonly `YYYY-MM-DD`, but Rekordbox doesn't seem to enforce the format).
+    /// TODO: check if Rekordbox constrains the format or allows arbitrary text.
+    pub release_date: String,
+    /// Free text, commonly `YYYY-MM-DD` (see [`Self::release_date`]).
+    pub date_added: String,
+    /// Device-relative file path (e.g. `/Contents/Artist - Title.mp3`). Dedup key when non-empty.
+    pub file_path: String,
+    /// File name without path.
+    pub filename: String,
+    /// Host-side path to the artwork image source. Under the `artwork` feature it is decoded,
+    /// resized to 80×80 + 240×240, and written into `PIONEER/Artwork/` with an id-derived name;
+    /// the PDB `Artwork.path` is derived from the assigned id. Without the feature it is silently
+    /// ignored (no row, no file) — set it only when `artwork` is enabled.
+    pub artwork_path: String,
+    /// Track "message" field shown in Rekordbox.
+    pub message: String,
+    /// Tempo in BPM; encoded to centi-BPM (× 100) in the PDB.
+    pub tempo: f32,
+    /// Bitrate in kbps.
+    pub bitrate: u32,
+    /// Sample rate in Hz.
+    pub sample_rate: u32,
+    /// Bits per sample of the audio file.
+    pub sample_depth: u16,
+    /// Playback duration in seconds. PDB field is `u16` (ceiling ~18.2 h).
+    pub duration_secs: u16,
+    /// File size in bytes.
+    pub file_size: u32,
+    /// Track number within the album.
+    pub track_number: u32,
+    /// Disc number.
+    pub disc_number: u16,
+    /// Release year.
+    pub year: u16,
+    /// Number of times the track was played.
+    pub play_count: u16,
+    /// Raw byte; see the struct docs.
+    pub rating: u8,
+    /// Color label.
+    pub color: ColorIndex,
+    /// Audio file format.
+    pub file_type: FileType,
+    /// Whether stored hotcues auto-load on a CDJ. Maps to the PDB string `"ON"` / empty.
+    pub autoload_hotcues: bool,
+}
+
+impl Default for Track {
+    fn default() -> Self {
+        Self {
+            title: String::new(),
+            artist: String::new(),
+            album: String::new(),
+            genre: String::new(),
+            key: String::new(),
+            label: String::new(),
+            composer: String::new(),
+            remixer: String::new(),
+            orig_artist: String::new(),
+            comment: String::new(),
+            isrc: String::new(),
+            lyricist: String::new(),
+            mix_name: String::new(),
+            release_date: String::new(),
+            date_added: String::new(),
+            file_path: String::new(),
+            filename: String::new(),
+            artwork_path: String::new(),
+            message: String::new(),
+            tempo: 0.0,
+            bitrate: 0,
+            sample_rate: 0,
+            sample_depth: 0,
+            duration_secs: 0,
+            file_size: 0,
+            track_number: 0,
+            disc_number: 0,
+            year: 0,
+            play_count: 0,
+            rating: 0,
+            color: ColorIndex::None,
+            file_type: FileType::Unknown,
+            autoload_hotcues: false,
+        }
+    }
+}
+
+/// The outcome of [`DeviceExportWriter::add_track`]: either a freshly inserted track or an
+/// existing one returned because its `file_path` already existed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AddTrackOutcome {
+    /// The track id in the export.
+    pub id: TrackId,
+    /// `true` if a new row was inserted; `false` if an existing track was returned unchanged.
+    pub is_new: bool,
+}
+
+/// Builder for a Rekordbox device export: PDB database, setting files, directory structure.
+#[derive(Debug)]
+pub struct DeviceExportWriter {
+    db: Option<Database<fs::File>>,
+    #[allow(dead_code)]
+    layout: Layout,
+    next_track_id: u32,
+    next_artist_id: u32,
+    next_album_id: u32,
+    next_genre_id: u32,
+    next_key_id: u32,
+    next_label_id: u32,
+    #[cfg(feature = "artwork")]
+    next_artwork_id: u32,
+    next_playlist_node_id: u32,
+    track_ids: HashSet<u32>,
+    /// `id -> is_folder`. Root (id 0) is implicit — always valid as a parent, always a folder.
+    playlist_nodes: HashMap<u32, bool>,
+    tracks_by_path: HashMap<String, u32>,
+    playlist_entry_counts: HashMap<u32, u32>,
+    artists_by_name: HashMap<String, u32>,
+    albums_by_artist_and_name: HashMap<(u32, String), u32>,
+    genres_by_name: HashMap<String, u32>,
+    keys_by_canonical: HashMap<String, u32>,
+    labels_by_name: HashMap<String, u32>,
+    #[cfg(feature = "artwork")]
+    artwork_by_path: HashMap<String, u32>,
+}
+
+/// Fold a key name to a canonical form for dedup (`C Major`/`Cmaj`/`C MAJOR`/`Cmajor` → `Cmaj`),
+/// so they share one PDB Key row. The note letter keeps its case.
+///
+/// String-equality only: enharmonic equivalents (`B♭m` ≠ `A#m`), Camelot, and Open Key notation
+/// are not resolved — different spellings of the same pitch still create distinct rows.
+fn canonical_key_name(name: &str) -> String {
+    let trimmed = name.trim();
+    let lower = trimmed.to_lowercase();
+    let mut out = String::with_capacity(trimmed.len());
+    let mut i = 0;
+    while i < lower.len() {
+        let rest = &lower[i..];
+        // Order matters: longest tokens first. Each folds a mode/accidental word to its short form.
+        let folded = [
+            ("major", "maj"),
+            ("minor", "min"),
+            ("flat", "b"),
+            ("sharp", "#"),
+            ("maj", "maj"),
+            ("min", "min"),
+        ]
+        .into_iter()
+        .find_map(|(tok, emit)| rest.starts_with(tok).then_some((emit, tok.len())));
+        if let Some((emit, skip)) = folded {
+            out.push_str(emit);
+            i += skip;
+        } else {
+            // Not a recognized token: copy one original char through (preserves note case + any
+            // unicode like ♭/♯ fixed in the second pass below).
+            let ch = trimmed[i..].chars().next().expect("aligned with lower");
+            out.push(ch);
+            i += ch.len_utf8();
+        }
+    }
+
+    // Bare trailing 'm' is minor (e.g. "Cm" → "Cmin"). Only at end-of-string, and only if we
+    // didn't already end in maj/min.
+    if out.ends_with('m') && !out.ends_with("min") && !out.ends_with("maj") {
+        out.push_str("in");
+    }
+
+    // Fold unicode accidentals.
+    out.replace('\u{266d}', "b")
+        .replace('\u{266f}', "#")
+        .replace(' ', "")
+}
+
+/// PDB `Artwork.path` for `id`: `/PIONEER/Artwork/{folder}/a{id}.jpg`. Always references the
+/// thumbnail; the medium-resolution `_m` file is not tracked in the PDB.
+#[cfg(feature = "artwork")]
+fn artwork_device_path(id: u32) -> String {
+    format!("/PIONEER/Artwork/{}/a{id}.jpg", artwork_folder(id))
+}
+
+impl Drop for DeviceExportWriter {
+    /// Best-effort flush if `close` wasn't called. Cannot surface errors — call
+    /// [`DeviceExportWriter::close`] for a clean shutdown.
+    fn drop(&mut self) {
+        if let Some(db) = self.db.as_mut() {
+            let _ = db.flush();
+        }
+    }
+}
+
+/// Default `Setting` for a type. The `SettingType`→`default_*` mapping lives here (not in
+/// `layout`) because `Setting::default_*` is named per variant, not keyed by `SettingType`.
+fn default_setting(setting_type: SettingType) -> Setting {
+    match setting_type {
+        SettingType::DevSetting => Setting::default_devsetting(),
+        SettingType::DJMMySetting => Setting::default_djmmysetting(),
+        SettingType::MySetting => Setting::default_mysetting(),
+        SettingType::MySetting2 => Setting::default_mysetting2(),
+    }
+}
+
+impl DeviceExportWriter {
+    /// Borrows the live `Database`. `db` is `Some` until `close()` (which consumes `self`), so
+    /// no method observes a `None`.
+    fn db(&mut self) -> &mut Database<fs::File> {
+        self.db
+            .as_mut()
+            .expect("DeviceExportWriter.db always Some until close")
+    }
+    /// Create a new device export at `device_root`.
+    ///
+    /// Creates the `PIONEER`, `PIONEER/USBANLZ`, and `Contents` directories, an empty PDB
+    /// database, and the default setting files. Audio files and `ANLZ.*` analysis files are never
+    /// produced; artwork is copied only under the `artwork` feature (see the module docs).
+    ///
+    /// # Errors
+    ///
+    /// If directory creation, PDB creation, or setting file writing fails.
+    pub fn create(device_root: impl AsRef<Path>) -> Result<Self> {
+        let layout = Layout::new(device_root.as_ref().to_path_buf());
+
+        fs::create_dir_all(layout.rekordbox_dir())?;
+        fs::create_dir_all(layout.usbanlz_dir())?;
+        fs::create_dir_all(layout.contents_dir())?;
+
+        // PDB table layout, in the fixed index order Rekordbox expects on a device export. Each
+        // entry occupies one table index (0=Tracks, 1=Genres, …). The `Unknown(N)` entries are
+        // currently unknown tables, but they must stay in place so CDJ players don't crash.
+        let table_page_types: &[PageType] = &[
+            PageType::Plain(PlainPageType::Tracks),
+            PageType::Plain(PlainPageType::Genres),
+            PageType::Plain(PlainPageType::Artists),
+            PageType::Plain(PlainPageType::Albums),
+            PageType::Plain(PlainPageType::Labels),
+            PageType::Plain(PlainPageType::Keys),
+            PageType::Plain(PlainPageType::Colors),
+            PageType::Plain(PlainPageType::PlaylistTree),
+            PageType::Plain(PlainPageType::PlaylistEntries),
+            PageType::Unknown(9),
+            PageType::Unknown(10),
+            PageType::Plain(PlainPageType::HistoryPlaylists),
+            PageType::Plain(PlainPageType::HistoryEntries),
+            PageType::Plain(PlainPageType::Artwork),
+            PageType::Unknown(14),
+            PageType::Unknown(15),
+            PageType::Plain(PlainPageType::Columns),
+            PageType::Plain(PlainPageType::Menu),
+            PageType::Unknown(18),
+            PageType::Plain(PlainPageType::History),
+        ];
+
+        let file = fs::File::create(layout.export_pdb())?;
+        let mut db = Database::create(file, DatabaseType::Plain, table_page_types)?;
+
+        crate::pdb::defaults::insert_default_colors(&mut db)?;
+        crate::pdb::defaults::insert_default_columns(&mut db)?;
+        crate::pdb::defaults::insert_default_menus(&mut db)?;
+
+        for &(filename, setting_type) in DAT_FILES {
+            write_setting_file(&layout.dat_path(filename), &default_setting(setting_type))?;
+        }
+
+        Ok(Self {
+            db: Some(db),
+            layout,
+            // Counters start at 1: id 0 is the null/empty foreign key (returned by the empty-name
+            // branches of get_or_create_* and used for unset composer/orig-artist/remixer ids), so
+            // the first real row must be 1. Do not change to 0.
+            next_track_id: 1,
+            next_artist_id: 1,
+            next_album_id: 1,
+            next_genre_id: 1,
+            next_key_id: 1,
+            next_label_id: 1,
+            #[cfg(feature = "artwork")]
+            next_artwork_id: 1,
+            next_playlist_node_id: 1,
+            track_ids: HashSet::new(),
+            playlist_nodes: HashMap::new(),
+            tracks_by_path: HashMap::new(),
+            playlist_entry_counts: HashMap::new(),
+            artists_by_name: HashMap::new(),
+            albums_by_artist_and_name: HashMap::new(),
+            genres_by_name: HashMap::new(),
+            keys_by_canonical: HashMap::new(),
+            labels_by_name: HashMap::new(),
+            #[cfg(feature = "artwork")]
+            artwork_by_path: HashMap::new(),
+        })
+    }
+
+    /// Open an existing device export at the given path.
+    ///
+    /// Opens the existing PDB database and scans for the highest IDs in each
+    /// table category to continue adding rows with non-conflicting IDs.
+    ///
+    /// # Errors
+    ///
+    /// If the PDB cannot be opened or the table scanning fails.
+    pub fn open(device_root: impl AsRef<Path>) -> Result<Self> {
+        let layout = Layout::new(device_root.as_ref().to_path_buf());
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(layout.export_pdb())?;
+        let mut db = Database::open(file, DatabaseType::Plain)?;
+
+        // Each table's next free ID is one past the highest existing ID (0 when empty). We also
+        // rebuild the in-memory dedup/index maps so add_track stays O(1) per lookup.
+        let mut track_ids = HashSet::new();
+        let mut tracks_by_path = HashMap::new();
+        let next_track_id = db.iter_rows::<crate::pdb::Track>()?.fold(0u32, |max, t| {
+            track_ids.insert(t.id.0);
+            if let Ok(path) = t.offsets.inner.file_path.clone().into_string() {
+                if !path.is_empty() {
+                    tracks_by_path.entry(path).or_insert(t.id.0);
+                }
+            }
+            Ok(max.max(t.id.0))
+        })? + 1;
+
+        let mut artists_by_name = HashMap::new();
+        let next_artist_id = db.iter_rows::<crate::pdb::Artist>()?.fold(0u32, |max, a| {
+            if let Ok(name) = a.offsets.name.clone().into_string() {
+                artists_by_name.entry(name).or_insert(a.id.0);
+            }
+            Ok(max.max(a.id.0))
+        })? + 1;
+
+        let mut albums_by_artist_and_name = HashMap::new();
+        let next_album_id = db.iter_rows::<crate::pdb::Album>()?.fold(0u32, |max, a| {
+            if let Ok(name) = a.offsets.name.clone().into_string() {
+                albums_by_artist_and_name
+                    .entry((a.artist_id.0, name))
+                    .or_insert(a.id.0);
+            }
+            Ok(max.max(a.id.0))
+        })? + 1;
+
+        let mut genres_by_name = HashMap::new();
+        let next_genre_id = db.iter_rows::<crate::pdb::Genre>()?.fold(0u32, |max, g| {
+            if let Ok(name) = g.name.clone().into_string() {
+                genres_by_name.entry(name).or_insert(g.id.0);
+            }
+            Ok(max.max(g.id.0))
+        })? + 1;
+
+        let mut keys_by_canonical = HashMap::new();
+        let next_key_id = db.iter_rows::<crate::pdb::Key>()?.fold(0u32, |max, k| {
+            if let Ok(name) = k.name.clone().into_string() {
+                // Index under canonical form so later lookups collide.
+                keys_by_canonical
+                    .entry(canonical_key_name(&name))
+                    .or_insert(k.id.0);
+            }
+            Ok(max.max(k.id.0))
+        })? + 1;
+
+        let mut labels_by_name = HashMap::new();
+        let next_label_id = db.iter_rows::<crate::pdb::Label>()?.fold(0u32, |max, l| {
+            if let Ok(name) = l.name.clone().into_string() {
+                labels_by_name.entry(name).or_insert(l.id.0);
+            }
+            Ok(max.max(l.id.0))
+        })? + 1;
+
+        #[cfg(feature = "artwork")]
+        let (next_artwork_id, artwork_by_path) = {
+            let mut artwork_by_path = HashMap::new();
+            let next_artwork_id = db
+                .iter_rows::<crate::pdb::Artwork>()?
+                .fold(0u32, |max, a| {
+                    if let Ok(path) = a.path.clone().into_string() {
+                        artwork_by_path.entry(path).or_insert(a.id.0);
+                    }
+                    Ok(max.max(a.id.0))
+                })?
+                + 1;
+            (next_artwork_id, artwork_by_path)
+        };
+
+        let mut playlist_nodes = HashMap::new();
+        let next_playlist_node_id =
+            db.iter_rows::<crate::pdb::PlaylistTreeNode>()?
+                .fold(0u32, |max, p| {
+                    playlist_nodes.insert(p.id.0, p.is_folder());
+                    Ok(max.max(p.id.0))
+                })?
+                + 1;
+
+        // `max(entry_index) + 1` (not row count) so a reopened export with sparse indices doesn't
+        // collide with an existing index.
+        let mut playlist_entry_counts: HashMap<u32, u32> = HashMap::new();
+        db.iter_rows::<crate::pdb::PlaylistEntry>()?.for_each(|e| {
+            let entry = playlist_entry_counts.entry(e.playlist_id.0).or_insert(0);
+            *entry = (*entry).max(e.entry_index + 1);
+            Ok(())
+        })?;
+
+        Ok(Self {
+            db: Some(db),
+            layout,
+            next_track_id,
+            next_artist_id,
+            next_album_id,
+            next_genre_id,
+            next_key_id,
+            next_label_id,
+            #[cfg(feature = "artwork")]
+            next_artwork_id,
+            next_playlist_node_id,
+            track_ids,
+            playlist_nodes,
+            tracks_by_path,
+            playlist_entry_counts,
+            artists_by_name,
+            albums_by_artist_and_name,
+            genres_by_name,
+            keys_by_canonical,
+            labels_by_name,
+            #[cfg(feature = "artwork")]
+            artwork_by_path,
+        })
+    }
+
+    /// Add a track to the export from a domain [`Track`].
+    ///
+    /// Resolves (creating where needed) the Artist, Album, Genre, Key, Label, and Artwork rows,
+    /// then inserts a Track row pointing at them by ID.
+    ///
+    /// Idempotent on non-empty `file_path`: if a track with that path was already added (this
+    /// session or read back by [`open`](Self::open)), the existing [`TrackId`] is returned and no
+    /// new row is inserted. Tracks with an empty `file_path` are always inserted. Use
+    /// [`AddTrackOutcome::is_new`] to tell the cases apart.
+    ///
+    /// Pads `comment` with spaces if the row would fall under Rekordbox's 221-byte minimum.
+    ///
+    /// # Errors
+    ///
+    /// If any of the track's strings cannot be encoded.
+    ///
+    /// String encoding and row building happen before any IDs are allocated or rows inserted, so
+    /// a bad string leaves the export untouched. A mid-write IO failure can leave orphaned
+    /// dimension rows on an `open()`-ed device; this is not recovered automatically.
+    pub fn add_track(&mut self, track: &Track) -> Result<AddTrackOutcome> {
+        if !track.file_path.is_empty() {
+            if let Some(&id) = self.tracks_by_path.get(&track.file_path) {
+                return Ok(AddTrackOutcome {
+                    id: TrackId(id),
+                    is_new: false,
+                });
+            }
+        }
+
+        let (mut pdb_track, comment) = self.build_pdb_track(track)?;
+
+        let artist_id = self.get_or_create_artist(&track.artist)?;
+        let album_id = self.get_or_create_album(&track.album, artist_id)?;
+        let genre_id = self.get_or_create_genre(&track.genre)?;
+        let key_id = self.get_or_create_key(&track.key)?;
+        let label_id = self.get_or_create_label(&track.label)?;
+        let artwork_id = self.get_or_create_artwork(&track.artwork_path)?;
+
+        let composer_id = if track.composer.is_empty() {
+            0
+        } else {
+            self.get_or_create_artist(&track.composer)?
+        };
+        let orig_artist_id = if track.orig_artist.is_empty() {
+            0
+        } else {
+            self.get_or_create_artist(&track.orig_artist)?
+        };
+        let remixer_id = if track.remixer.is_empty() {
+            0
+        } else {
+            self.get_or_create_artist(&track.remixer)?
+        };
+
+        let track_id = self.next_track_id;
+        self.next_track_id += 1;
+
+        pdb_track.id = TrackId(track_id);
+        pdb_track.artist_id = ArtistId(artist_id);
+        pdb_track.album_id = AlbumId(album_id);
+        pdb_track.genre_id = GenreId(genre_id);
+        pdb_track.key_id = KeyId(key_id);
+        pdb_track.label_id = LabelId(label_id);
+        pdb_track.artwork_id = ArtworkId(artwork_id);
+        pdb_track.composer_id = ArtistId(composer_id);
+        pdb_track.orig_artist_id = ArtistId(orig_artist_id);
+        pdb_track.remixer_id = ArtistId(remixer_id);
+
+        self.db().add_row(Row::Plain(PlainRow::Track(pdb_track)))?;
+
+        self.track_ids.insert(track_id);
+        if !track.file_path.is_empty() {
+            self.tracks_by_path
+                .insert(track.file_path.clone(), track_id);
+        }
+
+        // `comment` isn't observable after insertion; kept for the dedicated auto-pad test.
+        let _ = comment;
+
+        Ok(AddTrackOutcome {
+            id: TrackId(track_id),
+            is_new: true,
+        })
+    }
+
+    /// Encode all strings, set scalar fields, grow `comment` past the 221-byte minimum. Allocates
+    /// no IDs, inserts nothing.
+    fn build_pdb_track(&self, track: &Track) -> Result<(crate::pdb::Track, String)> {
+        let mut pdb_track = crate::pdb::Track::default_row();
+        pdb_track.sample_rate = track.sample_rate;
+        pdb_track.sample_depth = track.sample_depth;
+        pdb_track.bitrate = track.bitrate;
+        pdb_track.duration = track.duration_secs;
+        pdb_track.file_size = track.file_size;
+        // PDB tempo is centi-BPM (BPM × 100).
+        pdb_track.tempo = (track.tempo * 100.0).round() as u32;
+        pdb_track.file_type = track.file_type.clone();
+        pdb_track.track_number = track.track_number;
+        pdb_track.disc_number = track.disc_number;
+        pdb_track.year = track.year;
+        pdb_track.play_count = track.play_count;
+        pdb_track.rating = track.rating;
+        pdb_track.color = track.color.clone();
+
+        // Only `comment` grows below; hoist the rest so they're encoded once.
+        let isrc = DeviceSQLString::new(&track.isrc)?;
+        let lyricist = DeviceSQLString::new(&track.lyricist)?;
+        let message = DeviceSQLString::new(&track.message)?;
+        let mix_name = DeviceSQLString::new(&track.mix_name)?;
+        let release_date = DeviceSQLString::new(&track.release_date)?;
+        let date_added = DeviceSQLString::new(&track.date_added)?;
+        let title = DeviceSQLString::new(&track.title)?;
+        let filename = DeviceSQLString::new(&track.filename)?;
+        let file_path = DeviceSQLString::new(&track.file_path)?;
+        let autoload_hotcues = if track.autoload_hotcues {
+            DeviceSQLString::new("ON")?
+        } else {
+            DeviceSQLString::empty()
+        };
+        {
+            let s = &mut pdb_track.offsets.inner;
+            s.isrc = isrc;
+            s.lyricist = lyricist;
+            s.message = message;
+            s.mix_name = mix_name;
+            s.release_date = release_date;
+            s.date_added = date_added;
+            s.title = title;
+            s.filename = filename;
+            s.file_path = file_path;
+            s.autoload_hotcues = autoload_hotcues;
+        }
+
+        // Grow `comment` with trailing spaces (semantically harmless free text) until the row
+        // meets the 221-byte minimum. Only `comment` is re-encoded each pass.
+        let mut comment = track.comment.clone();
+        loop {
+            pdb_track.offsets.inner.comment = DeviceSQLString::new(&comment)?;
+            if Database::<fs::File>::validate_track_row_size(&pdb_track).is_ok() {
+                break;
+            }
+            comment.push(' ');
+        }
+
+        Ok((pdb_track, comment))
+    }
+
+    /// Create a playlist folder and return its node ID.
+    ///
+    /// `parent_id` is [`PlaylistTreeNodeId::root()`] or an existing folder created by
+    /// [`create_playlist_folder`](Self::create_playlist_folder).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UnknownForeignKey`] if `parent_id` isn't the root or an existing folder (a playlist
+    /// id is rejected — only folders hold children).
+    pub fn create_playlist_folder(
+        &mut self,
+        name: &str,
+        parent_id: PlaylistTreeNodeId,
+    ) -> Result<PlaylistTreeNodeId> {
+        self.create_playlist_node(name, parent_id, true)
+    }
+
+    /// Create a playlist and return its node ID.
+    ///
+    /// `parent_id` is [`PlaylistTreeNodeId::root()`] or an existing folder created by
+    /// [`create_playlist_folder`](Self::create_playlist_folder).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UnknownForeignKey`] if `parent_id` isn't the root or an existing folder.
+    pub fn create_playlist(
+        &mut self,
+        name: &str,
+        parent_id: PlaylistTreeNodeId,
+    ) -> Result<PlaylistTreeNodeId> {
+        self.create_playlist_node(name, parent_id, false)
+    }
+
+    fn create_playlist_node(
+        &mut self,
+        name: &str,
+        parent_id: PlaylistTreeNodeId,
+        is_folder: bool,
+    ) -> Result<PlaylistTreeNodeId> {
+        if parent_id.0 != 0
+            && !self
+                .playlist_nodes
+                .get(&parent_id.0)
+                .copied()
+                .unwrap_or(false)
+        {
+            return Err(Error::UnknownForeignKey {
+                kind: ForeignKeyKind::PlaylistNode,
+                id: parent_id.0,
+            });
+        }
+
+        let id = self.next_playlist_node_id;
+        self.next_playlist_node_id += 1;
+
+        let node = PlaylistTreeNode::new(
+            PlaylistTreeNodeId(id),
+            parent_id,
+            DeviceSQLString::new(name)?,
+            is_folder,
+            0,
+        );
+
+        self.db()
+            .add_row(Row::Plain(PlainRow::PlaylistTreeNode(node)))?;
+
+        self.playlist_nodes.insert(id, is_folder);
+
+        Ok(PlaylistTreeNodeId(id))
+    }
+
+    /// Append a track to the end of a playlist. The entry position is assigned automatically.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UnknownForeignKey`] if `playlist_id` isn't an existing *playlist* (a folder id is
+    /// rejected — tracks go into playlists only), or `track_id` isn't an existing track.
+    pub fn add_track_to_playlist(
+        &mut self,
+        playlist_id: PlaylistTreeNodeId,
+        track_id: TrackId,
+    ) -> Result<()> {
+        if !self
+            .playlist_nodes
+            .get(&playlist_id.0)
+            .copied()
+            .map(|is_folder| !is_folder)
+            .unwrap_or(false)
+        {
+            return Err(Error::UnknownForeignKey {
+                kind: ForeignKeyKind::PlaylistNode,
+                id: playlist_id.0,
+            });
+        }
+        if !self.track_ids.contains(&track_id.0) {
+            return Err(Error::UnknownForeignKey {
+                kind: ForeignKeyKind::Track,
+                id: track_id.0,
+            });
+        }
+
+        let entry_index = self
+            .playlist_entry_counts
+            .get(&playlist_id.0)
+            .copied()
+            .unwrap_or(0);
+
+        let entry = PlaylistEntry {
+            entry_index,
+            track_id,
+            playlist_id,
+        };
+
+        self.db()
+            .add_row(Row::Plain(PlainRow::PlaylistEntry(entry)))?;
+
+        self.playlist_entry_counts
+            .insert(playlist_id.0, entry_index + 1);
+
+        Ok(())
+    }
+
+    /// Flush pending writes and close the PDB. Prefer this over relying on `Drop`, which can't
+    /// surface errors.
+    ///
+    /// # Errors
+    ///
+    /// If the flush or close fails.
+    pub fn close(mut self) -> Result<()> {
+        self.db
+            .take()
+            .expect("DeviceExportWriter.db always Some until close")
+            .close()
+    }
+
+    fn get_or_create<K, RowFn>(
+        db: &mut Database<fs::File>,
+        map: &mut HashMap<K, u32>,
+        next_id: &mut u32,
+        key: K,
+        key_empty: bool,
+        build: RowFn,
+    ) -> Result<u32>
+    where
+        K: Eq + std::hash::Hash + Clone,
+        RowFn: FnOnce(u32, &K) -> Result<Row>,
+    {
+        if key_empty {
+            return Ok(0);
+        }
+        if let Some(&id) = map.get(&key) {
+            return Ok(id);
+        }
+
+        let id = *next_id;
+        *next_id += 1;
+        let row = build(id, &key)?;
+        db.add_row(row)?;
+        map.insert(key.clone(), id);
+        Ok(id)
+    }
+
+    fn get_or_create_artist(&mut self, name: &str) -> Result<u32> {
+        Self::get_or_create(
+            self.db
+                .as_mut()
+                .expect("DeviceExportWriter.db always Some until close"),
+            &mut self.artists_by_name,
+            &mut self.next_artist_id,
+            name.to_string(),
+            name.is_empty(),
+            |id, name| {
+                Ok(Row::Plain(PlainRow::Artist(crate::pdb::Artist {
+                    subtype: crate::pdb::Subtype(0x60),
+                    index_shift: 0,
+                    id: crate::pdb::ArtistId(id),
+                    offsets: OffsetArrayContainer {
+                        offsets: MaybeCalculated::Calculated,
+                        inner: crate::pdb::TrailingName {
+                            name: DeviceSQLString::new(name)?,
+                        },
+                    },
+                })))
+            },
+        )
+    }
+
+    fn get_or_create_album(&mut self, name: &str, artist_id: u32) -> Result<u32> {
+        Self::get_or_create(
+            self.db
+                .as_mut()
+                .expect("DeviceExportWriter.db always Some until close"),
+            &mut self.albums_by_artist_and_name,
+            &mut self.next_album_id,
+            (artist_id, name.to_string()),
+            name.is_empty(),
+            |id, (artist, name): &(u32, String)| {
+                Ok(Row::Plain(PlainRow::Album(crate::pdb::Album {
+                    subtype: crate::pdb::Subtype(0x80),
+                    index_shift: 0,
+                    unknown2: 0,
+                    artist_id: crate::pdb::ArtistId(*artist),
+                    id: crate::pdb::AlbumId(id),
+                    unknown3: 0,
+                    offsets: OffsetArrayContainer {
+                        offsets: MaybeCalculated::Calculated,
+                        inner: crate::pdb::TrailingName {
+                            name: DeviceSQLString::new(name)?,
+                        },
+                    },
+                })))
+            },
+        )
+    }
+
+    fn get_or_create_genre(&mut self, name: &str) -> Result<u32> {
+        Self::get_or_create(
+            self.db
+                .as_mut()
+                .expect("DeviceExportWriter.db always Some until close"),
+            &mut self.genres_by_name,
+            &mut self.next_genre_id,
+            name.to_string(),
+            name.is_empty(),
+            |id, name| {
+                Ok(Row::Plain(PlainRow::Genre(crate::pdb::Genre {
+                    id: crate::pdb::GenreId(id),
+                    name: DeviceSQLString::new(name)?,
+                })))
+            },
+        )
+    }
+
+    fn get_or_create_key(&mut self, name: &str) -> Result<u32> {
+        let canonical = canonical_key_name(name);
+        Self::get_or_create(
+            self.db
+                .as_mut()
+                .expect("DeviceExportWriter.db always Some until close"),
+            &mut self.keys_by_canonical,
+            &mut self.next_key_id,
+            canonical.clone(),
+            name.is_empty(),
+            |id, _canonical| {
+                // Store the canonical form so future lookups collide.
+                let key_name = if canonical.is_empty() {
+                    name
+                } else {
+                    &canonical
+                };
+                Ok(Row::Plain(PlainRow::Key(crate::pdb::Key {
+                    id: crate::pdb::KeyId(id),
+                    id2: id,
+                    name: DeviceSQLString::new(key_name)?,
+                })))
+            },
+        )
+    }
+
+    fn get_or_create_label(&mut self, name: &str) -> Result<u32> {
+        Self::get_or_create(
+            self.db
+                .as_mut()
+                .expect("DeviceExportWriter.db always Some until close"),
+            &mut self.labels_by_name,
+            &mut self.next_label_id,
+            name.to_string(),
+            name.is_empty(),
+            |id, name| {
+                Ok(Row::Plain(PlainRow::Label(crate::pdb::Label {
+                    id: crate::pdb::LabelId(id),
+                    name: DeviceSQLString::new(name)?,
+                })))
+            },
+        )
+    }
+
+    /// Without the `artwork` feature, producing no artwork at all: a raw copy of an unknown
+    /// format/size cannot be guaranteed readable by a CDJ, so we write nothing rather than risk a
+    /// broken image. Returns the null id `0`; no PDB row is created.
+    #[cfg(not(feature = "artwork"))]
+    fn get_or_create_artwork(&mut self, _path: &str) -> Result<u32> {
+        Ok(0)
+    }
+
+    /// With the `artwork` feature, resolve `path` (a host source file) to an artwork id: reuse an
+    /// existing one for the same source, or copy the image into the export (resizing to 80×80
+    /// thumbnail and 240×240 medium) and insert a new PDB `Artwork` row whose path is derived from
+    /// the assigned id. An empty `path` yields the null id `0` (no row, no copy).
+    #[cfg(feature = "artwork")]
+    fn get_or_create_artwork(&mut self, path: &str) -> Result<u32> {
+        if path.is_empty() {
+            return Ok(0);
+        }
+        if let Some(&id) = self.artwork_by_path.get(path) {
+            return Ok(id);
+        }
+
+        let id = self.next_artwork_id;
+        self.copy_artwork_file(path, id)?;
+        // Bump only after the copy succeeds, so a failure leaves no id gap and no orphan row.
+        self.next_artwork_id += 1;
+
+        let row = Row::Plain(PlainRow::Artwork(Artwork {
+            id: ArtworkId(id),
+            path: DeviceSQLString::new(&artwork_device_path(id))?,
+        }));
+        self.db().add_row(row)?;
+
+        self.artwork_by_path.insert(path.to_string(), id);
+        Ok(id)
+    }
+
+    /// Decode `source`, resize to the 80×80 thumbnail and 240×240 medium, and write both as JPEG
+    /// under their id-derived shard paths. Creates the shard directory. Decode/encode/IO errors
+    /// propagate to the caller.
+    #[cfg(feature = "artwork")]
+    fn copy_artwork_file(&self, source: &str, id: u32) -> Result<()> {
+        use image::imageops::FilterType;
+        use image::ImageReader;
+        use std::path::PathBuf;
+
+        let source_path = PathBuf::from(source);
+        let img = ImageReader::open(&source_path)
+            .map_err(|e| Error::ArtworkError {
+                path: source_path.clone(),
+                message: e.to_string(),
+            })?
+            .decode()
+            .map_err(|e| Error::ArtworkError {
+                path: source_path.clone(),
+                message: e.to_string(),
+            })?;
+
+        let dest = self.layout.artwork_file(id);
+        fs::create_dir_all(dest.parent().expect("artwork path always has a folder"))?;
+
+        let thumb = img.resize_to_fill(80, 80, FilterType::Lanczos3);
+        thumb
+            .to_rgb8()
+            .save(&dest)
+            .map_err(|e| Error::ArtworkError {
+                path: dest.clone(),
+                message: e.to_string(),
+            })?;
+
+        let medium_dest = self.layout.artwork_m_file(id);
+        let medium = img.resize_to_fill(240, 240, FilterType::Lanczos3);
+        medium
+            .to_rgb8()
+            .save(&medium_dest)
+            .map_err(|e| Error::ArtworkError {
+                path: medium_dest.clone(),
+                message: e.to_string(),
+            })?;
+
+        Ok(())
+    }
+}
+
+fn write_setting_file(path: &Path, setting: &Setting) -> Result<()> {
+    let mut buf = Cursor::new(Vec::new());
+    setting
+        .write_options(&mut buf, binrw::Endian::Little, (false,))
+        .map_err(Error::BinrwError)?;
+    fs::write(path, buf.into_inner())?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_canonical_key_name_major_forms() {
+        assert_eq!(canonical_key_name("C Major"), "Cmaj");
+        assert_eq!(canonical_key_name("Cmaj"), "Cmaj");
+        assert_eq!(canonical_key_name("C MAJOR"), "Cmaj");
+        assert_eq!(canonical_key_name("Cmajor"), "Cmaj");
+        // The note letter's case is preserved as given.
+        assert_eq!(canonical_key_name("c MAJOR"), "cmaj");
+    }
+
+    #[test]
+    fn test_canonical_key_name_minor_forms() {
+        assert_eq!(canonical_key_name("A Minor"), "Amin");
+        assert_eq!(canonical_key_name("Amin"), "Amin");
+        assert_eq!(canonical_key_name("A MINOR"), "Amin");
+        // Bare 'm' suffix is minor.
+        assert_eq!(canonical_key_name("Am"), "Amin");
+    }
+
+    #[test]
+    fn test_canonical_key_name_accidentals() {
+        // Unicode ♭/♯ and the words flat/sharp all collapse to ascii.
+        assert_eq!(canonical_key_name("B\u{266d}m"), "Bbmin");
+        assert_eq!(canonical_key_name("B flat minor"), "Bbmin");
+        assert_eq!(canonical_key_name("F\u{266f}m"), "F#min");
+        assert_eq!(canonical_key_name("F sharp Minor"), "F#min");
+    }
+
+    #[test]
+    fn test_canonical_key_name_dedup_equivalence() {
+        // The whole point: these must all collide so they share one PDB Key row.
+        let a = canonical_key_name("D Major");
+        let b = canonical_key_name("Dmaj");
+        assert_eq!(a, b);
+    }
+
+    // open() must reuse an existing named row instead of duplicating it.
+    #[test]
+    fn open_then_add_does_not_duplicate_named_row() {
+        let dir =
+            std::env::temp_dir().join(format!("rekordcrate-export-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let t = Track {
+            title: "song".into(),
+            artist: "Dup Artist".into(),
+            album: "Dup Album".into(),
+            genre: "Dup Genre".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        // Dedup must survive to disk: exactly one "Dup Artist".
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let count = dev
+            .db()
+            .iter_rows::<crate::pdb::Artist>()
+            .unwrap()
+            .filter(|row| Ok(row.offsets.name.clone().into_string().unwrap() == "Dup Artist"))
+            .count()
+            .unwrap();
+        assert_eq!(count, 1, "open() must not duplicate an existing artist");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // add_track is idempotent on a non-empty file_path, in-session and across open()/close().
+    #[test]
+    fn add_track_dedups_on_file_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-track-dedup-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let first = dev.add_track(&t).unwrap();
+        let second = dev.add_track(&t).unwrap();
+        assert_eq!(
+            first.id, second.id,
+            "re-adding the same file_path must return the existing id"
+        );
+        assert!(first.is_new, "the first add must be flagged new");
+        assert!(!second.is_new, "the duplicate add must be flagged not new");
+        dev.close().unwrap();
+
+        // Across open(): the path is read back, so re-adding still dedups.
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let third = dev.add_track(&t).unwrap();
+        assert_eq!(
+            first.id, third.id,
+            "re-adding after open() must return the existing id"
+        );
+        assert!(!third.is_new, "the post-reopen add must be flagged not new");
+        dev.close().unwrap();
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let count = dev
+            .db()
+            .iter_rows::<crate::pdb::Track>()
+            .unwrap()
+            .count()
+            .unwrap();
+        assert_eq!(count, 1, "dedup must keep exactly one Track row on disk");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The playlist methods reject ids that don't reference an existing row.
+    #[test]
+    fn playlist_methods_reject_unknown_foreign_keys() {
+        let dir =
+            std::env::temp_dir().join(format!("rekordcrate-export-fk-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+
+        // parent_id root() is the tree root and always valid.
+        let folder = dev
+            .create_playlist_folder("Folder", PlaylistTreeNodeId::root())
+            .unwrap();
+        let playlist = dev.create_playlist("Playlist", folder).unwrap();
+
+        // Unknown parent: 999 was never created.
+        let err = dev
+            .create_playlist("Orphan", PlaylistTreeNodeId(999))
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::PlaylistNode && id == 999),
+            "unknown parent_id must be rejected, got {err:?}"
+        );
+
+        // A valid track so add_track_to_playlist's track check has something to find.
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            ..Default::default()
+        };
+        let track = dev.add_track(&t).unwrap().id;
+
+        // Unknown playlist id.
+        let err = dev
+            .add_track_to_playlist(PlaylistTreeNodeId(999), track)
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::PlaylistNode && id == 999),
+            "unknown playlist_id must be rejected, got {err:?}"
+        );
+
+        // Unknown track id.
+        let err = dev
+            .add_track_to_playlist(playlist, TrackId(999))
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::Track && id == 999),
+            "unknown track_id must be rejected, got {err:?}"
+        );
+
+        // The happy path still works.
+        dev.add_track_to_playlist(playlist, track).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A playlist id is rejected as a parent (only folders hold children), and a folder id is
+    // rejected as an add_track_to_playlist target (only playlists hold tracks).
+    #[test]
+    fn playlist_tree_enforces_folder_vs_playlist_roles() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tree-shape-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let folder = dev
+            .create_playlist_folder("Folder", PlaylistTreeNodeId::root())
+            .unwrap();
+        let playlist = dev.create_playlist("Playlist", folder).unwrap();
+
+        // The playlist exists, but it's a leaf, not a folder.
+        let err = dev.create_playlist("Child", playlist).unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::PlaylistNode && id == playlist.0),
+            "a playlist id must be rejected as a parent, got {err:?}"
+        );
+
+        // The folder exists, but tracks go into playlists only.
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            ..Default::default()
+        };
+        let track = dev.add_track(&t).unwrap().id;
+        let err = dev.add_track_to_playlist(folder, track).unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::PlaylistNode && id == folder.0),
+            "a folder id must be rejected as a track container, got {err:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // add_track_to_playlist assigns dense entry indices 0,1,2,…, in-session and across
+    // open()/close() (where the counter is rebuilt from existing rows).
+    #[test]
+    fn add_track_to_playlist_auto_indexes() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-autoindex-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mk = |i: u32| Track {
+            title: format!("song{i}"),
+            filename: format!("song{i}.mp3"),
+            file_path: format!("/Contents/song{i}.mp3"),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let playlist = dev
+            .create_playlist("P", PlaylistTreeNodeId::root())
+            .unwrap();
+        let t0 = dev.add_track(&mk(0)).unwrap().id;
+        let t1 = dev.add_track(&mk(1)).unwrap().id;
+        let t2 = dev.add_track(&mk(2)).unwrap().id;
+        dev.add_track_to_playlist(playlist, t0).unwrap();
+        dev.add_track_to_playlist(playlist, t1).unwrap();
+        dev.add_track_to_playlist(playlist, t2).unwrap();
+        dev.close().unwrap();
+
+        // After open() the counter is rebuilt, so one more append lands at index 3.
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let t3 = dev.add_track(&mk(3)).unwrap().id;
+        dev.add_track_to_playlist(playlist, t3).unwrap();
+        dev.close().unwrap();
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let mut indices: Vec<u32> = dev
+            .db()
+            .iter_rows::<crate::pdb::PlaylistEntry>()
+            .unwrap()
+            .map(|e| Ok(e.entry_index))
+            .collect()
+            .unwrap();
+        indices.sort_unstable();
+        assert_eq!(
+            indices,
+            vec![0, 1, 2, 3],
+            "entry indices must be dense from 0"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A bare title + file_path (well under 221 bytes) must succeed, with the writer growing
+    // `comment` with spaces internally.
+    #[test]
+    fn add_track_auto_pads_under_minimum_row_size() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-autopad-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let t = Track {
+            title: "tiny".into(),
+            file_path: "/Contents/tiny.mp3".into(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let outcome = dev.add_track(&t).unwrap();
+        assert!(outcome.is_new, "a fresh track must be flagged new");
+
+        dev.close().unwrap();
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let row = dev
+            .db()
+            .iter_rows::<crate::pdb::Track>()
+            .unwrap()
+            .find(|row| Ok(row.id == outcome.id))
+            .unwrap()
+            .unwrap();
+        let comment = row.offsets.inner.comment.clone().into_string().unwrap();
+        assert!(
+            comment.chars().all(|c| c == ' '),
+            "auto-pad must grow the comment with spaces only, got {comment:?}"
+        );
+        assert!(
+            !comment.is_empty(),
+            "auto-pad must have grown the comment past empty"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The sharding rule id/20+1, zero-padded to 5 digits, derived from the captured fixtures.
+    #[cfg(feature = "artwork")]
+    #[test]
+    fn artwork_device_path_sharding() {
+        assert_eq!(artwork_folder(1), "00001");
+        assert_eq!(artwork_folder(19), "00001");
+        assert_eq!(artwork_folder(20), "00002");
+        assert_eq!(artwork_folder(39), "00002");
+        assert_eq!(artwork_folder(40), "00003");
+        // The PDB path always references the thumbnail under its shard folder.
+        assert_eq!(artwork_device_path(1), "/PIONEER/Artwork/00001/a1.jpg");
+        assert_eq!(artwork_device_path(20), "/PIONEER/Artwork/00002/a20.jpg");
+    }
+
+    #[cfg(feature = "artwork")]
+    fn write_test_jpeg(path: &std::path::Path, w: u32, h: u32) {
+        use image::{ImageBuffer, Rgb, RgbImage};
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        let img: RgbImage = ImageBuffer::from_fn(w, h, |x, y| {
+            Rgb([(x * 10 % 255) as u8, (y * 10 % 255) as u8, 128])
+        });
+        img.save(path).unwrap();
+    }
+
+    // Under the artwork feature, add_track copies the source into the sharded dir under both the
+    // 80×80 thumbnail name and the 240×240 medium name, and stores the thumbnail path in the PDB.
+    #[cfg(feature = "artwork")]
+    #[test]
+    fn add_track_copies_artwork() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-artwork-copy-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let src = dir.join("src.png");
+        write_test_jpeg(&src, 200, 200);
+
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            artwork_path: src.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        let thumb = dir.join("PIONEER/Artwork/00001/a1.jpg");
+        let medium = dir.join("PIONEER/Artwork/00001/a1_m.jpg");
+        assert!(thumb.exists(), "thumbnail must be written at {thumb:?}");
+        assert!(medium.exists(), "medium must be written at {medium:?}");
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let row = dev
+            .db()
+            .iter_rows::<crate::pdb::Artwork>()
+            .unwrap()
+            .find(|_| Ok(true))
+            .unwrap()
+            .unwrap();
+        let path = row.path.clone().into_string().unwrap();
+        assert_eq!(
+            path, "/PIONEER/Artwork/00001/a1.jpg",
+            "PDB Artwork.path must reference the thumbnail"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Two tracks sharing one source dedup to a single artwork: one thumbnail, one medium on disk,
+    // one PDB row, and both tracks reference the same artwork id.
+    #[cfg(feature = "artwork")]
+    #[test]
+    fn add_track_dedups_artwork_by_source() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-artwork-dedup-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let src = dir.join("cover.png");
+        write_test_jpeg(&src, 100, 100);
+
+        let mk = |n: usize| Track {
+            title: format!("song{n}"),
+            filename: format!("song{n}.mp3"),
+            file_path: format!("/Contents/song{n}.mp3"),
+            artwork_path: src.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        dev.add_track(&mk(0)).unwrap();
+        dev.add_track(&mk(1)).unwrap();
+        dev.close().unwrap();
+
+        // One shard folder, one thumbnail, one medium.
+        let shard = dir.join("PIONEER/Artwork/00001");
+        let entries: Vec<_> = std::fs::read_dir(&shard)
+            .unwrap()
+            .collect::<std::io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            entries.len(),
+            2,
+            "expected exactly thumbnail + medium in {shard:?}"
+        );
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let count = dev
+            .db()
+            .iter_rows::<crate::pdb::Artwork>()
+            .unwrap()
+            .count()
+            .unwrap();
+        assert_eq!(count, 1, "dedup must keep exactly one Artwork row on disk");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The written files are resized to the Rekordbox dimensions regardless of source size.
+    #[cfg(feature = "artwork")]
+    #[test]
+    fn add_track_artwork_dimensions() {
+        use image::ImageReader;
+
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-artwork-dims-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let src = dir.join("cover.png");
+        write_test_jpeg(&src, 200, 200);
+
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            artwork_path: src.to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        let thumb = ImageReader::open(dir.join("PIONEER/Artwork/00001/a1.jpg"))
+            .unwrap()
+            .into_dimensions()
+            .unwrap();
+        assert_eq!(thumb, (80, 80), "thumbnail must be 80×80");
+
+        let medium = ImageReader::open(dir.join("PIONEER/Artwork/00001/a1_m.jpg"))
+            .unwrap()
+            .into_dimensions()
+            .unwrap();
+        assert_eq!(medium, (240, 240), "medium must be 240×240");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Without the artwork feature, setting artwork_path is a silent no-op: no Artwork dir, no row,
+    // and the track's artwork_id is the null id 0.
+    #[cfg(not(feature = "artwork"))]
+    #[test]
+    fn artwork_noop_without_feature() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-artwork-noop-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            artwork_path: "/nonexistent/cover.jpg".into(),
+            ..Default::default()
+        };
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let outcome = dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        assert!(
+            !dir.join("PIONEER/Artwork").exists(),
+            "no artwork dir must be created without the feature"
+        );
+
+        let mut dev = DeviceExportWriter::open(&dir).unwrap();
+        let row = dev
+            .db()
+            .iter_rows::<crate::pdb::Track>()
+            .unwrap()
+            .find(|row| Ok(row.id == outcome.id))
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.artwork_id.0, 0,
+            "without the feature the track must reference the null artwork id"
+        );
+
+        let artwork_count = dev
+            .db()
+            .iter_rows::<crate::pdb::Artwork>()
+            .unwrap()
+            .count()
+            .unwrap();
+        assert_eq!(artwork_count, 0, "no Artwork row must be written");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -27,7 +27,8 @@ use crate::pdb::string::DeviceSQLString;
 use crate::pdb::Artwork;
 use crate::pdb::{
     AlbumId, ArtistId, ArtworkId, DatabaseType, GenreId, KeyId, LabelId, PageType, PlainPageType,
-    PlainRow, PlaylistEntry, PlaylistTreeNode, PlaylistTreeNodeId, Row, TrackId,
+    PlainRow, PlaylistEntry, PlaylistTreeNode, PlaylistTreeNodeId, Row, Subtype, Track as PdbTrack,
+    TrackId, TrackStrings,
 };
 use crate::setting::{Setting, SettingType};
 use crate::util::{ColorIndex, FileType, MaybeCalculated};
@@ -592,22 +593,6 @@ impl DeviceExportWriter {
     /// Encode all strings, set scalar fields, grow `comment` past the 221-byte minimum. Allocates
     /// no IDs, inserts nothing.
     fn build_pdb_track(&self, track: &Track) -> Result<(crate::pdb::Track, String)> {
-        let mut pdb_track = crate::pdb::Track::default_row();
-        pdb_track.sample_rate = track.sample_rate;
-        pdb_track.sample_depth = track.sample_depth;
-        pdb_track.bitrate = track.bitrate;
-        pdb_track.duration = track.duration_secs;
-        pdb_track.file_size = track.file_size;
-        // PDB tempo is centi-BPM (BPM × 100).
-        pdb_track.tempo = (track.tempo * 100.0).round() as u32;
-        pdb_track.file_type = track.file_type.clone();
-        pdb_track.track_number = track.track_number;
-        pdb_track.disc_number = track.disc_number;
-        pdb_track.year = track.year;
-        pdb_track.play_count = track.play_count;
-        pdb_track.rating = track.rating;
-        pdb_track.color = track.color.clone();
-
         // Only `comment` grows below; hoist the rest so they're encoded once.
         let isrc = DeviceSQLString::new(&track.isrc)?;
         let lyricist = DeviceSQLString::new(&track.lyricist)?;
@@ -623,19 +608,67 @@ impl DeviceExportWriter {
         } else {
             DeviceSQLString::empty()
         };
-        {
-            let s = &mut pdb_track.offsets.inner;
-            s.isrc = isrc;
-            s.lyricist = lyricist;
-            s.message = message;
-            s.mix_name = mix_name;
-            s.release_date = release_date;
-            s.date_added = date_added;
-            s.title = title;
-            s.filename = filename;
-            s.file_path = file_path;
-            s.autoload_hotcues = autoload_hotcues;
-        }
+
+        let mut pdb_track = PdbTrack {
+            // Reverse-engineered constants observed on fresh Rekordbox track rows.
+            subtype: Subtype(0x24),
+            index_shift: 0,
+            bitmask: 788_224,
+            unknown5: 41,
+            sample_rate: track.sample_rate,
+            sample_depth: track.sample_depth,
+            bitrate: track.bitrate,
+            duration: track.duration_secs,
+            file_size: track.file_size,
+            // PDB tempo is centi-BPM (BPM × 100).
+            tempo: (track.tempo * 100.0).round() as u32,
+            file_type: track.file_type.clone(),
+            track_number: track.track_number,
+            disc_number: track.disc_number,
+            year: track.year,
+            play_count: track.play_count,
+            rating: track.rating,
+            color: track.color.clone(),
+            composer_id: ArtistId(0),
+            artwork_id: ArtworkId(0),
+            key_id: KeyId(0),
+            orig_artist_id: ArtistId(0),
+            label_id: LabelId(0),
+            remixer_id: ArtistId(0),
+            genre_id: GenreId(0),
+            album_id: AlbumId(0),
+            artist_id: ArtistId(0),
+            id: TrackId(0),
+            unknown2: 0,
+            unknown3: 0,
+            unknown4: 0,
+            offsets: OffsetArrayContainer {
+                offsets: MaybeCalculated::Calculated,
+                inner: TrackStrings {
+                    isrc,
+                    lyricist,
+                    unknown_string2: DeviceSQLString::new("1")?,
+                    unknown_string3: DeviceSQLString::new("1")?,
+                    unknown_string4: DeviceSQLString::empty(),
+                    message,
+                    publish_track_information: DeviceSQLString::new("ON")?,
+                    autoload_hotcues,
+                    unknown_string5: DeviceSQLString::empty(),
+                    unknown_string6: DeviceSQLString::empty(),
+                    date_added,
+                    release_date,
+                    mix_name,
+                    unknown_string7: DeviceSQLString::empty(),
+                    analyze_path: DeviceSQLString::empty(),
+                    analyze_date: DeviceSQLString::empty(),
+                    comment: DeviceSQLString::empty(),
+                    title,
+                    unknown_string8: DeviceSQLString::empty(),
+                    filename,
+                    file_path,
+                },
+            },
+        };
 
         // Grow `comment` with trailing spaces (semantically harmless free text) until the row
         // meets the 221-byte minimum. Only `comment` is re-encoded each pass.

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -6,18 +6,25 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-//! Builds a Rekordbox USB export: the PDB database (`export.pdb`), the `PIONEER/*.DAT` setting
-//! files, and the `PIONEER`/`PIONEER/USBANLZ`/`Contents` directory layout.
+//! Builds a Rekordbox USB export from scratch or adds tracks to an existing one. A high-level
+//! builder that does most of the work for you and deals with the quirks of the underlying
+//! database format.
 //!
-//! With the `artwork` feature enabled, it also copies each track's [`Track::artwork_path`] into
-//! `PIONEER/Artwork/{folder}/`, resizing to the 80×80 thumbnail (`a{id}.jpg`) and the 240×240
-//! medium (`a{id}_m.jpg`) that newer Rekordbox versions expect. Without the feature, artwork is a
-//! no-op: a raw copy of an unknown format/size can't be guaranteed CDJ-readable, so nothing is
-//! written. It never copies audio files into `Contents` or generates `PIONEER/USBANLZ` analysis
-//! files (`ANLZ.*`). The API is append-only — existing rows cannot be updated or deleted; re-add
-//! via a fresh export instead.
+//! This module never copies audio files into `Contents` or generates `PIONEER/USBANLZ` analysis
+//! files (`ANLZ.*`). Also, the API is append-only, existing rows cannot be updated or deleted.
+//! So if you want to make edits, you should either open the `pdb` files with
+//! `pdb::io::Database::open` (and thus deal with the format intricacies yourself) or re-add via
+//! a fresh export instead.
+//!
+//! For each track's [`Track::artwork_path`], an `Artwork` PDB row is always created with an
+//! id-derived device path. With the `artwork` feature enabled, the source image is also decoded,
+//! resized to the 80×80 thumbnail (`a{id}.jpg`) and 240×240 (`a{id}_m.jpg`) that newer Rekordbox
+//! versions expect, and copied into `PIONEER/Artwork/{folder}/`. Without the feature only the
+//! PDB row is written and copying the image files is omitted, so the caller must place them at
+//! the id-derived shard path themselves.
+//!
+//! See [`crate::device::layout`].
 
-#[cfg(feature = "artwork")]
 use crate::device::layout::artwork_folder;
 use crate::device::layout::{Layout, DAT_FILES};
 use crate::pdb::ext::{
@@ -26,7 +33,6 @@ use crate::pdb::ext::{
 use crate::pdb::io::Database;
 use crate::pdb::offset_array::OffsetArrayContainer;
 use crate::pdb::string::DeviceSQLString;
-#[cfg(feature = "artwork")]
 use crate::pdb::Artwork;
 use crate::pdb::{
     AlbumId, ArtistId, ArtworkId, DatabaseType, GenreId, KeyId, LabelId, PageType, PlainPageType,
@@ -93,10 +99,10 @@ pub struct Track {
     pub file_path: String,
     /// File name without path.
     pub filename: String,
-    /// Host-side path to the artwork image source. Under the `artwork` feature it is decoded,
-    /// resized to 80×80 + 240×240, and written into `PIONEER/Artwork/` with an id-derived name;
-    /// the PDB `Artwork.path` is derived from the assigned id. Without the feature it is silently
-    /// ignored (no row, no file) — set it only when `artwork` is enabled.
+    /// Host-side path to the artwork image source. Always produces an `Artwork` PDB row with an
+    /// id-derived [`crate::pdb::Artwork::path`] (`/PIONEER/Artwork/{folder}/a{id}.jpg`); under the
+    /// `artwork` feature the image is also resized to 80×80 + 240×240, and copied there. Empty
+    /// means no artwork (null id, no row).
     pub artwork_path: String,
     /// Track "message" field shown in Rekordbox.
     pub message: String,
@@ -198,7 +204,6 @@ pub struct DeviceExportWriter {
     next_genre_id: u32,
     next_key_id: u32,
     next_label_id: u32,
-    #[cfg(feature = "artwork")]
     next_artwork_id: u32,
     next_playlist_node_id: u32,
     // Shared id space for categories and leaf tags; 0 is the null foreign key, so both start at 1.
@@ -223,7 +228,6 @@ pub struct DeviceExportWriter {
     tags_by_key: HashMap<(u32, String), u32>,
     /// `category_id -> next leaf position` (dense from 0 within a category).
     tag_leaf_counts: HashMap<u32, u32>,
-    #[cfg(feature = "artwork")]
     artwork_by_path: HashMap<String, u32>,
 }
 
@@ -276,7 +280,6 @@ fn canonical_key_name(name: &str) -> String {
 
 /// PDB `Artwork.path` for `id`: `/PIONEER/Artwork/{folder}/a{id}.jpg`. Always references the
 /// thumbnail; the medium-resolution `_m` file is not tracked in the PDB.
-#[cfg(feature = "artwork")]
 fn artwork_device_path(id: u32) -> String {
     format!("/PIONEER/Artwork/{}/a{id}.jpg", artwork_folder(id))
 }
@@ -379,7 +382,6 @@ impl DeviceExportWriter {
             next_genre_id: 1,
             next_key_id: 1,
             next_label_id: 1,
-            #[cfg(feature = "artwork")]
             next_artwork_id: 1,
             next_playlist_node_id: 1,
             next_tag_id: 1,
@@ -397,7 +399,6 @@ impl DeviceExportWriter {
             tag_categories: HashSet::new(),
             tags_by_key: HashMap::new(),
             tag_leaf_counts: HashMap::new(),
-            #[cfg(feature = "artwork")]
             artwork_by_path: HashMap::new(),
         })
     }
@@ -479,20 +480,16 @@ impl DeviceExportWriter {
             Ok(max.max(l.id.0))
         })? + 1;
 
-        #[cfg(feature = "artwork")]
-        let (next_artwork_id, artwork_by_path) = {
-            let mut artwork_by_path = HashMap::new();
-            let next_artwork_id = db
-                .iter_rows::<crate::pdb::Artwork>()?
-                .fold(0u32, |max, a| {
-                    if let Ok(path) = a.path.clone().into_string() {
-                        artwork_by_path.entry(path).or_insert(a.id.0);
-                    }
-                    Ok(max.max(a.id.0))
-                })?
-                + 1;
-            (next_artwork_id, artwork_by_path)
-        };
+        let mut artwork_by_path = HashMap::new();
+        let next_artwork_id = db
+            .iter_rows::<crate::pdb::Artwork>()?
+            .fold(0u32, |max, a| {
+                if let Ok(path) = a.path.clone().into_string() {
+                    artwork_by_path.entry(path).or_insert(a.id.0);
+                }
+                Ok(max.max(a.id.0))
+            })?
+            + 1;
 
         let mut playlist_nodes = HashMap::new();
         let next_playlist_node_id =
@@ -551,7 +548,6 @@ impl DeviceExportWriter {
             next_genre_id,
             next_key_id,
             next_label_id,
-            #[cfg(feature = "artwork")]
             next_artwork_id,
             next_playlist_node_id,
             next_tag_id,
@@ -569,7 +565,6 @@ impl DeviceExportWriter {
             tag_categories,
             tags_by_key,
             tag_leaf_counts,
-            #[cfg(feature = "artwork")]
             artwork_by_path,
         })
     }
@@ -1162,19 +1157,11 @@ impl DeviceExportWriter {
         )
     }
 
-    /// Without the `artwork` feature, producing no artwork at all: a raw copy of an unknown
-    /// format/size cannot be guaranteed readable by a CDJ, so we write nothing rather than risk a
-    /// broken image. Returns the null id `0`; no PDB row is created.
-    #[cfg(not(feature = "artwork"))]
-    fn get_or_create_artwork(&mut self, _path: &str) -> Result<u32> {
-        Ok(0)
-    }
-
-    /// With the `artwork` feature, resolve `path` (a host source file) to an artwork id: reuse an
-    /// existing one for the same source, or copy the image into the export (resizing to 80×80
-    /// thumbnail and 240×240 medium) and insert a new PDB `Artwork` row whose path is derived from
-    /// the assigned id. An empty `path` yields the null id `0` (no row, no copy).
-    #[cfg(feature = "artwork")]
+    // TODO(acrilique): Currently this does the same thing whether the `artwork` feature is enabled
+    // or not, except that the feature enables copying and resizing the artwork file to the device's
+    // artwork folder. If the feature is disabled, the caller must ensure the file is already present
+    // at the expected path, but this implies the caller should know what that path is, which is
+    // currently not exposed. Needs work.
     fn get_or_create_artwork(&mut self, path: &str) -> Result<u32> {
         if path.is_empty() {
             return Ok(0);
@@ -1184,7 +1171,10 @@ impl DeviceExportWriter {
         }
 
         let id = self.next_artwork_id;
-        self.copy_artwork_file(path, id)?;
+        #[cfg(feature = "artwork")]
+        {
+            self.copy_artwork_file(path, id)?;
+        }
         // Bump only after the copy succeeds, so a failure leaves no id gap and no orphan row.
         self.next_artwork_id += 1;
 
@@ -1815,13 +1805,14 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // Without the artwork feature, setting artwork_path is a silent no-op: no Artwork dir, no row,
-    // and the track's artwork_id is the null id 0.
+    // Without the artwork feature, a non-empty artwork_path still allocates an Artwork row with an
+    // id-derived device path (so the PDB is consistent), but the image files are NOT copied — the
+    // caller owns placing them at the shard path. The track references the allocated artwork id.
     #[cfg(not(feature = "artwork"))]
     #[test]
-    fn artwork_noop_without_feature() {
+    fn artwork_allocates_row_without_copy() {
         let dir = std::env::temp_dir().join(format!(
-            "rekordcrate-export-artwork-noop-test-{}",
+            "rekordcrate-export-artwork-nofeat-test-{}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&dir);
@@ -1838,31 +1829,49 @@ mod tests {
         let outcome = dev.add_track(&t).unwrap();
         dev.close().unwrap();
 
+        // No image files written — the caller's responsibility without the feature.
         assert!(
             !dir.join("PIONEER/Artwork").exists(),
-            "no artwork dir must be created without the feature"
+            "no artwork dir/files must be created without the feature"
         );
 
         let mut dev = DeviceExportWriter::open(&dir).unwrap();
-        let row = dev
-            .db()
-            .iter_rows::<crate::pdb::Track>()
-            .unwrap()
-            .find(|row| Ok(row.id == outcome.id))
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            row.artwork_id.0, 0,
-            "without the feature the track must reference the null artwork id"
-        );
 
-        let artwork_count = dev
+        // The track references the allocated artwork id (not the null id 0). Copy the scalar out so
+        // the row borrow ends before the next `db()` call.
+        let artwork_id = {
+            let track_row = dev
+                .db()
+                .iter_rows::<crate::pdb::Track>()
+                .unwrap()
+                .find(|row| Ok(row.id == outcome.id))
+                .unwrap()
+                .unwrap();
+            assert_ne!(
+                track_row.artwork_id.0, 0,
+                "track must reference the allocated artwork id, not the null id"
+            );
+            track_row.artwork_id.0
+        };
+
+        // Exactly one Artwork row, with the id-derived thumbnail path.
+        let artwork_rows: Vec<_> = dev
             .db()
             .iter_rows::<crate::pdb::Artwork>()
             .unwrap()
-            .count()
+            .collect::<Vec<_>>()
             .unwrap();
-        assert_eq!(artwork_count, 0, "no Artwork row must be written");
+        assert_eq!(artwork_rows.len(), 1, "one Artwork row must be written");
+        assert_eq!(
+            artwork_rows[0].id.0, artwork_id,
+            "Artwork row id must match the track's artwork_id"
+        );
+        let path = artwork_rows[0].path.clone().into_string().unwrap();
+        assert_eq!(
+            path,
+            artwork_device_path(artwork_id),
+            "Artwork.path must be the id-derived device path"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -31,7 +31,7 @@ use crate::pdb::{
     TrackId, TrackStrings,
 };
 use crate::setting::{Setting, SettingType};
-use crate::util::{ColorIndex, FileType, MaybeCalculated};
+use crate::util::{ColorIndex, FileType, MaybeCalculated, Rating};
 use crate::{Error, Result};
 use binrw::BinWrite;
 use fallible_iterator::FallibleIterator;
@@ -49,10 +49,9 @@ pub use crate::util::ForeignKeyKind;
 /// tempo). Experts needing fields not exposed here should drive a `pdb::Track` row directly via
 /// [`crate::pdb::io::Database`].
 ///
-/// `rating` is a raw byte passed straight through to the PDB. Rekordbox's encoding is unknown;
-/// Pioneer's XML spec documents `0/51/102/153/204/255` for 0–5 stars, but we have not confirmed the
-/// PDB uses the same mapping.
-/// TODO: confirm the PDB rating encoding against real hardware, then encode 0–5 stars internally.
+/// `rating` is a typed [`Rating`] (0–5 stars); the writer encodes it to the raw PDB byte
+/// (`0..=5`, confirmed against a real Rekordbox export — not the XML's
+/// `0/51/102/153/204/255`).
 #[derive(Debug, Clone)]
 pub struct Track {
     /// Track title.
@@ -81,8 +80,8 @@ pub struct Track {
     pub lyricist: String,
     /// Remix/mix name.
     pub mix_name: String,
-    /// Free text (commonly `YYYY-MM-DD`, but Rekordbox doesn't seem to enforce the format).
-    /// TODO: check if Rekordbox constrains the format or allows arbitrary text.
+    /// Free text. Rekordbox itself writes strict `YYYY-MM-DD` or empty here, but this field is
+    /// passed through verbatim so callers can probe hardware behavior with arbitrary strings.
     pub release_date: String,
     /// Free text, commonly `YYYY-MM-DD` (see [`Self::release_date`]).
     pub date_added: String,
@@ -117,8 +116,8 @@ pub struct Track {
     pub year: u16,
     /// Number of times the track was played.
     pub play_count: u16,
-    /// Raw byte; see the struct docs.
-    pub rating: u8,
+    /// Star rating (0–5); see the struct docs.
+    pub rating: Rating,
     /// Color label.
     pub color: ColorIndex,
     /// Audio file format.
@@ -159,7 +158,7 @@ impl Default for Track {
             disc_number: 0,
             year: 0,
             play_count: 0,
-            rating: 0,
+            rating: Rating::Zero,
             color: ColorIndex::None,
             file_type: FileType::Unknown,
             autoload_hotcues: false,
@@ -627,7 +626,7 @@ impl DeviceExportWriter {
             disc_number: track.disc_number,
             year: track.year,
             play_count: track.play_count,
-            rating: track.rating,
+            rating: track.rating.to_byte(),
             color: track.color.clone(),
             composer_id: ArtistId(0),
             artwork_id: ArtworkId(0),

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -16,7 +16,6 @@
 //! written. It never copies audio files into `Contents` or generates `PIONEER/USBANLZ` analysis
 //! files (`ANLZ.*`). The API is append-only — existing rows cannot be updated or deleted; re-add
 //! via a fresh export instead.
-//! TODO(acrilique): maybe we should make all pdb structs and fields public for now as a workaround
 
 #[cfg(feature = "artwork")]
 use crate::device::layout::artwork_folder;

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -16,15 +16,14 @@
 //! `pdb::io::Database::open` (and thus deal with the format intricacies yourself) or re-add via
 //! a fresh export instead.
 //!
-//! For each track's [`Track::artwork_path`], an `Artwork` PDB row is always created with an
-//! id-derived device path. With the `artwork` feature enabled, the source image is also decoded,
-//! resized to the 80×80 thumbnail (`a{id}.jpg`) and 240×240 (`a{id}_m.jpg`) that newer Rekordbox
-//! versions expect, and copied into `PIONEER/Artwork/{folder}/`. Without the feature only the
-//! PDB row is written and copying the image files is omitted, so the caller must place them at
-//! the id-derived shard path themselves.
+//! Per-track artwork: with the `artwork` feature, `Track::artwork_source` is a host-side path
+//! the writer decodes, resizes (80×80 + 240×240), and copies into `PIONEER/Artwork/{folder}/`.
+//! Without it, `Track::artwork_device_path` is stored in the `Artwork` row verbatim and the
+//! caller owns placing the image files.
 //!
 //! See [`crate::device::layout`].
 
+#[cfg(feature = "artwork")]
 use crate::device::layout::artwork_folder;
 use crate::device::layout::{Layout, DAT_FILES};
 use crate::pdb::ext::{
@@ -99,11 +98,12 @@ pub struct Track {
     pub file_path: String,
     /// File name without path.
     pub filename: String,
-    /// Host-side path to the artwork image source. Always produces an `Artwork` PDB row with an
-    /// id-derived [`crate::pdb::Artwork::path`] (`/PIONEER/Artwork/{folder}/a{id}.jpg`); under the
-    /// `artwork` feature the image is also resized to 80×80 + 240×240, and copied there. Empty
-    /// means no artwork (null id, no row).
-    pub artwork_path: String,
+    #[cfg(feature = "artwork")]
+    /// Host-side source path. Writer decodes, resizes, copies into `PIONEER/Artwork/`. Empty = none.
+    pub artwork_source: String,
+    #[cfg(not(feature = "artwork"))]
+    /// Device path stored verbatim in the `Artwork` row. Caller owns the files. Empty = none.
+    pub artwork_device_path: String,
     /// Track "message" field shown in Rekordbox.
     pub message: String,
     /// Tempo in BPM; encoded to centi-BPM (× 100) in the PDB.
@@ -136,6 +136,20 @@ pub struct Track {
     pub autoload_hotcues: bool,
 }
 
+impl Track {
+    /// The active artwork field: `artwork_source` with the feature, `artwork_device_path` without.
+    fn artwork_input(&self) -> &str {
+        #[cfg(feature = "artwork")]
+        {
+            &self.artwork_source
+        }
+        #[cfg(not(feature = "artwork"))]
+        {
+            &self.artwork_device_path
+        }
+    }
+}
+
 impl Default for Track {
     fn default() -> Self {
         Self {
@@ -156,7 +170,10 @@ impl Default for Track {
             date_added: String::new(),
             file_path: String::new(),
             filename: String::new(),
-            artwork_path: String::new(),
+            #[cfg(feature = "artwork")]
+            artwork_source: String::new(),
+            #[cfg(not(feature = "artwork"))]
+            artwork_device_path: String::new(),
             message: String::new(),
             tempo: 0.0,
             bitrate: 0,
@@ -278,8 +295,8 @@ fn canonical_key_name(name: &str) -> String {
         .replace(' ', "")
 }
 
-/// PDB `Artwork.path` for `id`: `/PIONEER/Artwork/{folder}/a{id}.jpg`. Always references the
-/// thumbnail; the medium-resolution `_m` file is not tracked in the PDB.
+/// Id-derived `Artwork.path`: `/PIONEER/Artwork/{folder}/a{id}.jpg` (thumbnail; `_m` not tracked).
+#[cfg(feature = "artwork")]
 fn artwork_device_path(id: u32) -> String {
     format!("/PIONEER/Artwork/{}/a{id}.jpg", artwork_folder(id))
 }
@@ -605,7 +622,7 @@ impl DeviceExportWriter {
         let genre_id = self.get_or_create_genre(&track.genre)?;
         let key_id = self.get_or_create_key(&track.key)?;
         let label_id = self.get_or_create_label(&track.label)?;
-        let artwork_id = self.get_or_create_artwork(&track.artwork_path)?;
+        let artwork_id = self.get_or_create_artwork(track.artwork_input())?;
 
         let composer_id = if track.composer.is_empty() {
             0
@@ -1157,11 +1174,6 @@ impl DeviceExportWriter {
         )
     }
 
-    // TODO(acrilique): Currently this does the same thing whether the `artwork` feature is enabled
-    // or not, except that the feature enables copying and resizing the artwork file to the device's
-    // artwork folder. If the feature is disabled, the caller must ensure the file is already present
-    // at the expected path, but this implies the caller should know what that path is, which is
-    // currently not exposed. Needs work.
     fn get_or_create_artwork(&mut self, path: &str) -> Result<u32> {
         if path.is_empty() {
             return Ok(0);
@@ -1175,12 +1187,22 @@ impl DeviceExportWriter {
         {
             self.copy_artwork_file(path, id)?;
         }
-        // Bump only after the copy succeeds, so a failure leaves no id gap and no orphan row.
+        // Bump only after the copy succeeds, so a failure leaves no id gap.
         self.next_artwork_id += 1;
 
+        let device_path = {
+            #[cfg(feature = "artwork")]
+            {
+                artwork_device_path(id)
+            }
+            #[cfg(not(feature = "artwork"))]
+            {
+                path.to_string()
+            }
+        };
         let row = Row::Plain(PlainRow::Artwork(Artwork {
             id: ArtworkId(id),
-            path: DeviceSQLString::new(&artwork_device_path(id))?,
+            path: DeviceSQLString::new(&device_path)?,
         }));
         self.db().add_row(row)?;
 
@@ -1682,7 +1704,7 @@ mod tests {
             title: "song".into(),
             filename: "song.mp3".into(),
             file_path: "/Contents/song.mp3".into(),
-            artwork_path: src.to_string_lossy().into_owned(),
+            artwork_source: src.to_string_lossy().into_owned(),
             ..Default::default()
         };
 
@@ -1730,7 +1752,7 @@ mod tests {
             title: format!("song{n}"),
             filename: format!("song{n}.mp3"),
             file_path: format!("/Contents/song{n}.mp3"),
-            artwork_path: src.to_string_lossy().into_owned(),
+            artwork_source: src.to_string_lossy().into_owned(),
             ..Default::default()
         };
 
@@ -1782,7 +1804,7 @@ mod tests {
             title: "song".into(),
             filename: "song.mp3".into(),
             file_path: "/Contents/song.mp3".into(),
-            artwork_path: src.to_string_lossy().into_owned(),
+            artwork_source: src.to_string_lossy().into_owned(),
             ..Default::default()
         };
 
@@ -1805,23 +1827,22 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // Without the artwork feature, a non-empty artwork_path still allocates an Artwork row with an
-    // id-derived device path (so the PDB is consistent), but the image files are NOT copied — the
-    // caller owns placing them at the shard path. The track references the allocated artwork id.
+    // Without the feature, the caller's device path is stored verbatim; no files are written.
     #[cfg(not(feature = "artwork"))]
     #[test]
-    fn artwork_allocates_row_without_copy() {
+    fn artwork_stores_caller_path_without_copy() {
         let dir = std::env::temp_dir().join(format!(
             "rekordcrate-export-artwork-nofeat-test-{}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&dir);
 
+        let caller_path = "/PIONEER/Artwork/00007/a137.jpg";
         let t = Track {
             title: "song".into(),
             filename: "song.mp3".into(),
             file_path: "/Contents/song.mp3".into(),
-            artwork_path: "/nonexistent/cover.jpg".into(),
+            artwork_device_path: caller_path.into(),
             ..Default::default()
         };
 
@@ -1837,9 +1858,8 @@ mod tests {
 
         let mut dev = DeviceExportWriter::open(&dir).unwrap();
 
-        // The track references the allocated artwork id (not the null id 0). Copy the scalar out so
-        // the row borrow ends before the next `db()` call.
-        let artwork_id = {
+        // The track references the allocated artwork id (not 0). Copy out to end the borrow.
+        let _artwork_id = {
             let track_row = dev
                 .db()
                 .iter_rows::<crate::pdb::Track>()
@@ -1854,7 +1874,7 @@ mod tests {
             track_row.artwork_id.0
         };
 
-        // Exactly one Artwork row, with the id-derived thumbnail path.
+        // One Artwork row; path is the caller's string verbatim.
         let artwork_rows: Vec<_> = dev
             .db()
             .iter_rows::<crate::pdb::Artwork>()
@@ -1862,15 +1882,10 @@ mod tests {
             .collect::<Vec<_>>()
             .unwrap();
         assert_eq!(artwork_rows.len(), 1, "one Artwork row must be written");
-        assert_eq!(
-            artwork_rows[0].id.0, artwork_id,
-            "Artwork row id must match the track's artwork_id"
-        );
         let path = artwork_rows[0].path.clone().into_string().unwrap();
         assert_eq!(
-            path,
-            artwork_device_path(artwork_id),
-            "Artwork.path must be the id-derived device path"
+            path, caller_path,
+            "Artwork.path must be the caller-supplied string, stored verbatim"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/device/writer.rs
+++ b/src/device/writer.rs
@@ -20,6 +20,9 @@
 #[cfg(feature = "artwork")]
 use crate::device::layout::artwork_folder;
 use crate::device::layout::{Layout, DAT_FILES};
+use crate::pdb::ext::{
+    ExtPageType, ExtRow, ParentId, TagId, TagOrCategory, TagOrCategoryStrings, TrackTag,
+};
 use crate::pdb::io::Database;
 use crate::pdb::offset_array::OffsetArrayContainer;
 use crate::pdb::string::DeviceSQLString;
@@ -38,6 +41,7 @@ use fallible_iterator::FallibleIterator;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Cursor;
+use std::num::NonZero;
 use std::path::Path;
 
 /// Re-export of [`crate::util::ForeignKeyKind`], for callers reaching it via this module.
@@ -176,10 +180,16 @@ pub struct AddTrackOutcome {
     pub is_new: bool,
 }
 
+/// Opaque id of a tag category created by [`DeviceExportWriter::create_tag_category`]. Pass it to
+/// [`DeviceExportWriter::add_tags_to_track`] to group leaf tags under the category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TagCategoryId(pub u32);
+
 /// Builder for a Rekordbox device export: PDB database, setting files, directory structure.
 #[derive(Debug)]
 pub struct DeviceExportWriter {
     db: Option<Database<fs::File>>,
+    ext_db: Option<Database<fs::File>>,
     #[allow(dead_code)]
     layout: Layout,
     next_track_id: u32,
@@ -191,6 +201,12 @@ pub struct DeviceExportWriter {
     #[cfg(feature = "artwork")]
     next_artwork_id: u32,
     next_playlist_node_id: u32,
+    // Shared id space for categories and leaf tags; 0 is the null foreign key, so both start at 1.
+    next_tag_id: u32,
+    /// Next `position` for a top-level category (0-based, as on real exports).
+    next_category_position: u32,
+    /// Per-row monotonic counter driving `index_shift` (`0x20`/row).
+    next_tag_row_index: u32,
     track_ids: HashSet<u32>,
     /// `id -> is_folder`. Root (id 0) is implicit — always valid as a parent, always a folder.
     playlist_nodes: HashMap<u32, bool>,
@@ -201,6 +217,12 @@ pub struct DeviceExportWriter {
     genres_by_name: HashMap<String, u32>,
     keys_by_canonical: HashMap<String, u32>,
     labels_by_name: HashMap<String, u32>,
+    /// Created tag category ids, for `add_tags_to_track` FK validation.
+    tag_categories: HashSet<u32>,
+    /// `(category_id, label) -> tag id` leaf dedup.
+    tags_by_key: HashMap<(u32, String), u32>,
+    /// `category_id -> next leaf position` (dense from 0 within a category).
+    tag_leaf_counts: HashMap<u32, u32>,
     #[cfg(feature = "artwork")]
     artwork_by_path: HashMap<String, u32>,
 }
@@ -265,6 +287,9 @@ impl Drop for DeviceExportWriter {
     fn drop(&mut self) {
         if let Some(db) = self.db.as_mut() {
             let _ = db.flush();
+        }
+        if let Some(ext_db) = self.ext_db.as_mut() {
+            let _ = ext_db.flush();
         }
     }
 }
@@ -343,6 +368,7 @@ impl DeviceExportWriter {
 
         Ok(Self {
             db: Some(db),
+            ext_db: None,
             layout,
             // Counters start at 1: id 0 is the null/empty foreign key (returned by the empty-name
             // branches of get_or_create_* and used for unset composer/orig-artist/remixer ids), so
@@ -356,6 +382,9 @@ impl DeviceExportWriter {
             #[cfg(feature = "artwork")]
             next_artwork_id: 1,
             next_playlist_node_id: 1,
+            next_tag_id: 1,
+            next_category_position: 0,
+            next_tag_row_index: 0,
             track_ids: HashSet::new(),
             playlist_nodes: HashMap::new(),
             tracks_by_path: HashMap::new(),
@@ -365,6 +394,9 @@ impl DeviceExportWriter {
             genres_by_name: HashMap::new(),
             keys_by_canonical: HashMap::new(),
             labels_by_name: HashMap::new(),
+            tag_categories: HashSet::new(),
+            tags_by_key: HashMap::new(),
+            tag_leaf_counts: HashMap::new(),
             #[cfg(feature = "artwork")]
             artwork_by_path: HashMap::new(),
         })
@@ -480,6 +512,8 @@ impl DeviceExportWriter {
 
         Ok(Self {
             db: Some(db),
+            // ext PDB is never read back by `open()` — any tags a prior session wrote are lost.
+            ext_db: None,
             layout,
             next_track_id,
             next_artist_id,
@@ -490,6 +524,9 @@ impl DeviceExportWriter {
             #[cfg(feature = "artwork")]
             next_artwork_id,
             next_playlist_node_id,
+            next_tag_id: 1,
+            next_category_position: 0,
+            next_tag_row_index: 0,
             track_ids,
             playlist_nodes,
             tracks_by_path,
@@ -499,6 +536,9 @@ impl DeviceExportWriter {
             genres_by_name,
             keys_by_canonical,
             labels_by_name,
+            tag_categories: HashSet::new(),
+            tags_by_key: HashMap::new(),
+            tag_leaf_counts: HashMap::new(),
             #[cfg(feature = "artwork")]
             artwork_by_path,
         })
@@ -805,6 +845,135 @@ impl DeviceExportWriter {
         Ok(())
     }
 
+    /// Create a top-level tag category (e.g. "Genre", "My Tags") in `exportExt.pdb` and return its
+    /// id. Leaf tags are grouped under a category via [`add_tags_to_track`](Self::add_tags_to_track).
+    /// The ext PDB is created lazily on first use.
+    ///
+    /// # Errors
+    ///
+    /// [`Error`] if the name can't be encoded or the row can't be written.
+    pub fn create_tag_category(&mut self, name: &str) -> Result<TagCategoryId> {
+        let id = self.next_tag_id;
+        self.next_tag_id += 1;
+        let position = self.next_category_position;
+        self.next_category_position += 1;
+
+        let row_index = self.next_tag_row_index;
+        self.next_tag_row_index += 1;
+        self.ext_db_mut().add_row(Row::Ext(ExtRow::Tag(tag_row(
+            ParentId(None),
+            position,
+            TagId(id),
+            true,
+            row_index,
+            name,
+        )?)))?;
+
+        self.tag_categories.insert(id);
+        Ok(TagCategoryId(id))
+    }
+
+    /// Associate `tags` with `track_id` under `category` in `exportExt.pdb`. Empty labels are
+    /// dropped; duplicate labels (within this call or already existing under the same category)
+    /// collapse to one leaf row, so each `(category, label)` pair produces at most one junction
+    /// row per track. The ext PDB is created lazily on first use.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UnknownForeignKey`] if `track_id` isn't an existing track or `category` isn't a
+    /// category created by [`create_tag_category`](Self::create_tag_category), or [`Error`] if a
+    /// string can't be encoded.
+    pub fn add_tags_to_track(
+        &mut self,
+        track_id: TrackId,
+        category: TagCategoryId,
+        tags: &[String],
+    ) -> Result<()> {
+        if !self.track_ids.contains(&track_id.0) {
+            return Err(Error::UnknownForeignKey {
+                kind: ForeignKeyKind::Track,
+                id: track_id.0,
+            });
+        }
+        if !self.tag_categories.contains(&category.0) {
+            return Err(Error::UnknownForeignKey {
+                kind: ForeignKeyKind::TagCategory,
+                id: category.0,
+            });
+        }
+        let mut seen: HashSet<&str> = HashSet::new();
+        let non_empty: Vec<&str> = tags
+            .iter()
+            .map(String::as_str)
+            .filter(|label| !label.is_empty() && seen.insert(label))
+            .collect();
+        if non_empty.is_empty() {
+            return Ok(());
+        }
+
+        for label in non_empty {
+            let tag_id = self.get_or_create_tag(category, label)?;
+            self.ext_db_mut()
+                .add_row(Row::Ext(ExtRow::TrackTag(TrackTag {
+                    track_id,
+                    tag_id: TagId(tag_id),
+                    unknown_const: 3,
+                })))?;
+        }
+        Ok(())
+    }
+
+    /// Reuse the leaf tag for `(category, label)` if it exists, else insert a new leaf row under
+    /// `category` and remember it.
+    fn get_or_create_tag(&mut self, category: TagCategoryId, label: &str) -> Result<u32> {
+        let key = (category.0, label.to_string());
+        if let Some(&id) = self.tags_by_key.get(&key) {
+            return Ok(id);
+        }
+
+        let id = self.next_tag_id;
+        self.next_tag_id += 1;
+        let position = self.tag_leaf_counts.get(&category.0).copied().unwrap_or(0);
+        self.tag_leaf_counts.insert(category.0, position + 1);
+
+        let row_index = self.next_tag_row_index;
+        self.next_tag_row_index += 1;
+        self.ext_db_mut().add_row(Row::Ext(ExtRow::Tag(tag_row(
+            ParentId(NonZero::new(category.0)),
+            position,
+            TagId(id),
+            false,
+            row_index,
+            label,
+        )?)))?;
+
+        self.tags_by_key.insert(key, id);
+        Ok(id)
+    }
+
+    fn ext_db_mut(&mut self) -> &mut Database<fs::File> {
+        if self.ext_db.is_none() {
+            let ext_path = self.layout.export_ext_pdb();
+            if let Some(parent) = ext_path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            // panic on IO failure. Returning Result from every tag call would add a `?`
+            // to the hot path for a failure (unwritable device) that surfaces loudly a few lines
+            // later anyway. Revisit if a caller needs graceful handling.
+            let file = fs::File::create(&ext_path).expect("can create exportExt.pdb");
+            let table_page_types = [
+                PageType::Ext(ExtPageType::Tag),
+                PageType::Ext(ExtPageType::TrackTag),
+            ];
+            let ext_db = Database::create(file, DatabaseType::Ext, &table_page_types)
+                .expect("can create ext PDB");
+            self.ext_db = Some(ext_db);
+        }
+        self.ext_db
+            .as_mut()
+            .expect("ext_db was just initialized above")
+    }
+
     /// Flush pending writes and close the PDB. Prefer this over relying on `Drop`, which can't
     /// surface errors.
     ///
@@ -815,7 +984,11 @@ impl DeviceExportWriter {
         self.db
             .take()
             .expect("DeviceExportWriter.db always Some until close")
-            .close()
+            .close()?;
+        if let Some(ext_db) = self.ext_db.take() {
+            ext_db.close()?;
+        }
+        Ok(())
     }
 
     fn get_or_create<K, RowFn>(
@@ -1050,6 +1223,38 @@ fn write_setting_file(path: &Path, setting: &Setting) -> Result<()> {
         .map_err(Error::BinrwError)?;
     fs::write(path, buf.into_inner())?;
     Ok(())
+}
+
+/// Build a category or leaf tag row. `is_category` selects the `raw_is_category` flag
+/// (`0x01000000` for categories, `0` for leaves — confirmed against a real Rekordbox export).
+/// `row_index` is the per-row monotonic counter that drives `index_shift` (`0x20` per row, as
+/// observed on real exports). Leaf tag ids are sequential here, not the large random 32-bit values
+/// Rekordbox writes — unknown whether players care; revisit if round-trip fidelity is needed.
+fn tag_row(
+    parent_id: ParentId,
+    position: u32,
+    id: TagId,
+    is_category: bool,
+    row_index: u32,
+    name: &str,
+) -> Result<TagOrCategory> {
+    Ok(TagOrCategory {
+        subtype: Subtype(0x0680),
+        index_shift: (row_index * 0x20) as u16,
+        unknown1: 0,
+        unknown2: 0,
+        parent_id,
+        position,
+        id,
+        raw_is_category: u32::from(is_category) << 24,
+        offsets: OffsetArrayContainer {
+            offsets: MaybeCalculated::Calculated,
+            inner: TagOrCategoryStrings {
+                name: name.parse()?,
+                unknown: DeviceSQLString::empty(),
+            },
+        },
+    })
 }
 
 #[cfg(test)]
@@ -1589,5 +1794,274 @@ mod tests {
         assert_eq!(artwork_count, 0, "no Artwork row must be written");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn collect_ext_rows(
+        ext_db: &mut Database<std::fs::File>,
+    ) -> (Vec<TagOrCategory>, Vec<crate::pdb::ext::TrackTag>) {
+        use crate::pdb::ext::{ExtPageType, ExtRow};
+        use fallible_iterator::FallibleIterator;
+
+        let mut tags = Vec::new();
+        let mut track_tags = Vec::new();
+        let mut pages = ext_db
+            .iter_pages(PageType::Ext(ExtPageType::Tag))
+            .expect("Tag pages");
+        while let Some(page) = pages.next().expect("page") {
+            let Some(data) = page.content.as_data() else {
+                continue;
+            };
+            for row in data.rows.values() {
+                if let Row::Ext(ExtRow::Tag(t)) = row {
+                    tags.push(t.clone());
+                }
+            }
+        }
+        let mut pages = ext_db
+            .iter_pages(PageType::Ext(ExtPageType::TrackTag))
+            .expect("TrackTag pages");
+        while let Some(page) = pages.next().expect("page") {
+            let Some(data) = page.content.as_data() else {
+                continue;
+            };
+            for row in data.rows.values() {
+                if let Row::Ext(ExtRow::TrackTag(t)) = row {
+                    track_tags.push(t.clone());
+                }
+            }
+        }
+        (tags, track_tags)
+    }
+
+    #[test]
+    fn tags_not_written_when_unused() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-none-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let t = Track {
+            title: "song".into(),
+            filename: "song.mp3".into(),
+            file_path: "/Contents/song.mp3".into(),
+            ..Default::default()
+        };
+        dev.add_track(&t).unwrap();
+        dev.close().unwrap();
+
+        assert!(
+            !dir.join("PIONEER/rekordbox/exportExt.pdb").exists(),
+            "no exportExt.pdb must be written when no track has tags"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_tags_creates_category_leaves_and_junctions() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-basic-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let t1 = Track {
+            title: "a".into(),
+            filename: "a.mp3".into(),
+            file_path: "/Contents/a.mp3".into(),
+            ..Default::default()
+        };
+        let t2 = Track {
+            title: "b".into(),
+            filename: "b.mp3".into(),
+            file_path: "/Contents/b.mp3".into(),
+            ..Default::default()
+        };
+        let id1 = dev.add_track(&t1).unwrap().id;
+        let id2 = dev.add_track(&t2).unwrap().id;
+
+        let cat = dev.create_tag_category("My Tags").unwrap();
+        dev.add_tags_to_track(id1, cat, &["Techno".into(), "Dub".into(), "Techno".into()])
+            .unwrap();
+        dev.add_tags_to_track(id2, cat, &["Dub".into(), "House".into()])
+            .unwrap();
+        dev.close().unwrap();
+
+        let mut ext_db = Database::open(
+            std::fs::File::open(dir.join("PIONEER/rekordbox/exportExt.pdb")).unwrap(),
+            DatabaseType::Ext,
+        )
+        .unwrap();
+        let (tags, track_tags) = collect_ext_rows(&mut ext_db);
+
+        let categories: Vec<_> = tags.iter().filter(|t| t.raw_is_category != 0).collect();
+        assert_eq!(categories.len(), 1);
+        // Confirmed against a real Rekordbox export: categories are `0x01000000`, not `1`.
+        assert_eq!(categories[0].raw_is_category, 0x01000000);
+        assert_eq!(categories[0].index_shift, 0x0000);
+        assert_eq!(
+            categories[0]
+                .offsets
+                .inner
+                .name
+                .clone()
+                .into_string()
+                .unwrap(),
+            "My Tags"
+        );
+        assert_eq!(categories[0].id.0, cat.0);
+        assert_eq!(categories[0].parent_id.0, None);
+
+        let mut leaves: Vec<_> = tags.iter().filter(|t| t.raw_is_category == 0).collect();
+        assert_eq!(leaves.len(), 3);
+        // Every leaf is a non-category row and lives under the caller's category.
+        for leaf in &leaves {
+            assert_eq!(leaf.raw_is_category, 0);
+            assert_eq!(leaf.parent_id.0.map(NonZero::get), Some(cat.0));
+        }
+        let leaf_names: Vec<String> = leaves
+            .iter()
+            .map(|t| t.offsets.inner.name.clone().into_string().unwrap())
+            .collect();
+        for expected in &["Techno", "Dub", "House"] {
+            assert!(
+                leaf_names.iter().any(|n| n == expected),
+                "{expected:?} missing, got {leaf_names:?}"
+            );
+        }
+        // `index_shift` grows by 0x20 per row across all tag rows (category + leaves), in write
+        // order — confirmed against a real Rekordbox export.
+        let mut sorted: Vec<u16> = tags.iter().map(|t| t.index_shift).collect();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert!(
+            sorted.windows(2).all(|w| w[1] - w[0] == 0x20),
+            "index_shift must step by 0x20 per row, got {sorted:?}"
+        );
+        // Category is written first (row_index 0); leaves follow. Sanity-check the leaf range.
+        leaves.sort_unstable_by_key(|t| t.index_shift);
+        assert_eq!(leaves[0].index_shift, 0x0020);
+        assert_eq!(leaves[1].index_shift, 0x0040);
+        assert_eq!(leaves[2].index_shift, 0x0060);
+
+        // t1: 2 tags, t2: 2 tags; the duplicate "Techno" within t1 must not add a junction, and the
+        // shared "Dub" must reuse one leaf row.
+        assert_eq!(track_tags.len(), 4);
+        for tt in &track_tags {
+            assert_eq!(tt.unknown_const, 3);
+        }
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_tags_rejects_unknown_track() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-fk-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let cat = dev.create_tag_category("My Tags").unwrap();
+        let err = dev
+            .add_tags_to_track(TrackId(999), cat, &["x".into()])
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::Track && id == 999),
+            "got {err:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_tags_rejects_unknown_category() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-cat-fk-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let t = Track {
+            title: "a".into(),
+            filename: "a.mp3".into(),
+            file_path: "/Contents/a.mp3".into(),
+            ..Default::default()
+        };
+        let id = dev.add_track(&t).unwrap().id;
+
+        let err = dev
+            .add_tags_to_track(id, TagCategoryId(999), &["x".into()])
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::TagCategory && id == 999),
+            "unknown category must be rejected, got {err:?}"
+        );
+        // The track FK is checked before the category FK, so a bad track id reports Track first.
+        let err = dev
+            .add_tags_to_track(TrackId(888), TagCategoryId(999), &["x".into()])
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::UnknownForeignKey { kind, id } if kind == ForeignKeyKind::Track && id == 888),
+            "track FK must be reported before category FK, got {err:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn add_tags_ignores_empty_labels() {
+        let dir = std::env::temp_dir().join(format!(
+            "rekordcrate-export-tags-empty-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let mut dev = DeviceExportWriter::create(&dir).unwrap();
+        let t = Track {
+            title: "a".into(),
+            filename: "a.mp3".into(),
+            file_path: "/Contents/a.mp3".into(),
+            ..Default::default()
+        };
+        let id = dev.add_track(&t).unwrap().id;
+
+        // No category yet, so the ext PDB must not exist even after an all-empty-labels call.
+        let cat = dev.create_tag_category("My Tags").unwrap();
+        dev.add_tags_to_track(id, cat, &["".into(), "".into()])
+            .unwrap();
+        // The category write already created exportExt.pdb; count its rows instead of asserting
+        // absence.
+        dev.close().unwrap();
+        let mut ext_db = Database::open(
+            std::fs::File::open(dir.join("PIONEER/rekordbox/exportExt.pdb")).unwrap(),
+            DatabaseType::Ext,
+        )
+        .unwrap();
+        let (tags, track_tags) = collect_ext_rows(&mut ext_db);
+        // Only the category row; no leaves, no junctions.
+        assert_eq!(tags.len(), 1);
+        assert_eq!(track_tags.len(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // Focused self-check for the two tag_row encodings confirmed against a real Rekordbox export:
+    // `raw_is_category` is `0x01000000` for a category and `0` for a leaf, and `index_shift` is
+    // `row_index * 0x20`.
+    #[test]
+    fn tag_row_encodings() {
+        let cat = tag_row(ParentId(None), 0, TagId(1), true, 0, "C").unwrap();
+        assert_eq!(cat.raw_is_category, 0x01000000);
+        assert_eq!(cat.index_shift, 0x0000);
+
+        let leaf = tag_row(ParentId(NonZero::new(1)), 0, TagId(2), false, 3, "L").unwrap();
+        assert_eq!(leaf.raw_is_category, 0);
+        assert_eq!(leaf.index_shift, 0x0060);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,6 @@ pub mod util;
 pub mod xml;
 pub(crate) mod xor;
 
-pub use crate::device::DeviceExportLoader;
+pub use crate::device::DeviceExportReader;
 pub use crate::util::RekordcrateError as Error;
 pub use crate::util::RekordcrateResult as Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@ pub mod util;
 pub mod xml;
 pub(crate) mod xor;
 
-pub use crate::device::{AddTrackOutcome, DeviceExportReader, DeviceExportWriter, Track};
+pub use crate::device::{
+    AddTrackOutcome, DeviceExportReader, DeviceExportWriter, TagCategoryId, Track,
+};
 pub use crate::pdb::{PlaylistTreeNodeId, TrackId};
 pub use crate::util::ForeignKeyKind;
 pub use crate::util::RekordcrateError as Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ pub mod util;
 pub mod xml;
 pub(crate) mod xor;
 
-pub use crate::device::DeviceExportReader;
+pub use crate::device::{AddTrackOutcome, DeviceExportReader, DeviceExportWriter, Track};
+pub use crate::pdb::{PlaylistTreeNodeId, TrackId};
+pub use crate::util::ForeignKeyKind;
 pub use crate::util::RekordcrateError as Error;
 pub use crate::util::RekordcrateResult as Result;

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,11 +190,11 @@ fn list_playlists(path: &Path) -> rekordcrate::Result<()> {
 
 fn export_playlists(path: &Path, output_dir: &Path) -> rekordcrate::Result<()> {
     use rekordcrate::device::{Playlist, PlaylistNode};
-    use rekordcrate::DeviceExportLoader;
+    use rekordcrate::DeviceExportReader;
     use std::collections::HashMap;
     use std::io::Write;
 
-    let loader = DeviceExportLoader::new(path.into());
+    let loader = DeviceExportReader::new(path.into());
     let export_path = loader.get_path();
     let mut db = loader.open_pdb_non_persistent()?;
 
@@ -257,9 +257,9 @@ fn export_playlists(path: &Path, output_dir: &Path) -> rekordcrate::Result<()> {
 }
 
 fn list_settings(path: &Path) -> rekordcrate::Result<()> {
-    use rekordcrate::DeviceExportLoader;
+    use rekordcrate::DeviceExportReader;
 
-    let loader = DeviceExportLoader::new(path.into());
+    let loader = DeviceExportReader::new(path.into());
     let settings = loader.load_settings();
 
     print!("{}", settings);

--- a/src/pdb/defaults.rs
+++ b/src/pdb/defaults.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Jan Holthuis <jan.holthuis@rub.de>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+// of the MPL was not distributed with this file, You can obtain one at
+// http://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+//! Default rows for colors, columns, and menus used in Pioneer database exports.
+//! This is what Rekordbox inserts when you create a new export without configuring anything.
+
+use super::io::Database;
+use super::string::DeviceSQLString;
+use super::{Color, ColumnEntry, Menu, MenuVisibility, PlainRow, Row};
+use crate::util::ColorIndex;
+use std::io::{Read, Seek, Write};
+
+const DEFAULT_COLORS: &[(u8, ColorIndex, &str)] = &[
+    (1, ColorIndex::Pink, "Pink"),
+    (2, ColorIndex::Red, "Red"),
+    (3, ColorIndex::Orange, "Orange"),
+    (4, ColorIndex::Yellow, "Yellow"),
+    (5, ColorIndex::Green, "Green"),
+    (6, ColorIndex::Aqua, "Aqua"),
+    (7, ColorIndex::Blue, "Blue"),
+    (8, ColorIndex::Purple, "Purple"),
+];
+
+const DEFAULT_COLUMNS: &[(u16, u16, &str)] = &[
+    (1, 128, "\u{fffa}GENRE\u{fffb}"),
+    (2, 129, "\u{fffa}ARTIST\u{fffb}"),
+    (3, 130, "\u{fffa}ALBUM\u{fffb}"),
+    (4, 131, "\u{fffa}TRACK\u{fffb}"),
+    (5, 133, "\u{fffa}BPM\u{fffb}"),
+    (6, 134, "\u{fffa}RATING\u{fffb}"),
+    (7, 135, "\u{fffa}YEAR\u{fffb}"),
+    (8, 136, "\u{fffa}REMIXER\u{fffb}"),
+    (9, 137, "\u{fffa}LABEL\u{fffb}"),
+    (10, 138, "\u{fffa}ORIGINAL ARTIST\u{fffb}"),
+    (11, 139, "\u{fffa}KEY\u{fffb}"),
+    (12, 141, "\u{fffa}CUE\u{fffb}"),
+    (13, 142, "\u{fffa}COLOR\u{fffb}"),
+    (14, 146, "\u{fffa}TIME\u{fffb}"),
+    (15, 147, "\u{fffa}BITRATE\u{fffb}"),
+    (16, 148, "\u{fffa}FILE NAME\u{fffb}"),
+    (17, 132, "\u{fffa}PLAYLIST\u{fffb}"),
+    (18, 152, "\u{fffa}HOT CUE BANK\u{fffb}"),
+    (19, 149, "\u{fffa}HISTORY\u{fffb}"),
+    (20, 145, "\u{fffa}SEARCH\u{fffb}"),
+    (21, 150, "\u{fffa}COMMENTS\u{fffb}"),
+    (22, 140, "\u{fffa}DATE ADDED\u{fffb}"),
+    (23, 151, "\u{fffa}DJ PLAY COUNT\u{fffb}"),
+    (24, 144, "\u{fffa}FOLDER\u{fffb}"),
+    (25, 161, "\u{fffa}DEFAULT\u{fffb}"),
+    (26, 162, "\u{fffa}ALPHABET\u{fffb}"),
+    (27, 170, "\u{fffa}MATCHING\u{fffb}"),
+];
+
+const DEFAULT_MENUS: &[(u16, u16, u8, MenuVisibility, u16)] = &[
+    (1, 1, 99, MenuVisibility::Hidden, 0),
+    (5, 6, 5, MenuVisibility::Hidden, 0),
+    (6, 7, 99, MenuVisibility::Hidden, 0),
+    (7, 8, 99, MenuVisibility::Hidden, 0),
+    (8, 9, 99, MenuVisibility::Hidden, 0),
+    (9, 10, 99, MenuVisibility::Hidden, 0),
+    (10, 11, 99, MenuVisibility::Hidden, 0),
+    (13, 15, 99, MenuVisibility::Hidden, 0),
+    (14, 19, 4, MenuVisibility::Hidden, 0),
+    (15, 20, 6, MenuVisibility::Hidden, 0),
+    (16, 21, 99, MenuVisibility::Hidden, 0),
+    (18, 23, 99, MenuVisibility::Hidden, 0),
+    (2, 2, 2, MenuVisibility::Visible, 1),
+    (3, 3, 3, MenuVisibility::Visible, 2),
+    (4, 4, 1, MenuVisibility::Visible, 3),
+    (11, 12, 99, MenuVisibility::Visible, 4),
+    (17, 5, 99, MenuVisibility::Visible, 5),
+    (19, 22, 99, MenuVisibility::Visible, 6),
+    (20, 18, 99, MenuVisibility::Visible, 7),
+    (27, 26, 99, MenuVisibility::Unknown(2), 8),
+    (24, 17, 99, MenuVisibility::Visible, 9),
+    (22, 27, 99, MenuVisibility::Visible, 10),
+];
+
+/// Insert the default color rows into the database.
+pub fn insert_default_colors<RW: Read + Write + Seek>(db: &mut Database<RW>) -> crate::Result<()> {
+    for &(id, ref color, name) in DEFAULT_COLORS {
+        db.add_row(Row::Plain(PlainRow::Color(Color {
+            unknown1: 0,
+            unknown2: id,
+            color: color.clone(),
+            unknown3: 0,
+            name: DeviceSQLString::new(name)?,
+        })))?;
+    }
+    Ok(())
+}
+
+/// Insert the default column rows into the database.
+pub fn insert_default_columns<RW: Read + Write + Seek>(db: &mut Database<RW>) -> crate::Result<()> {
+    for &(id, unknown0, name) in DEFAULT_COLUMNS {
+        db.add_row(Row::Plain(PlainRow::ColumnEntry(ColumnEntry {
+            id,
+            unknown0,
+            column_name: DeviceSQLString::new(name)?,
+        })))?;
+    }
+    Ok(())
+}
+
+/// Insert the default menu rows into the database.
+pub fn insert_default_menus<RW: Read + Write + Seek>(db: &mut Database<RW>) -> crate::Result<()> {
+    for &(category_id, content_pointer, unknown, ref visibility, sort_order) in DEFAULT_MENUS {
+        db.add_row(Row::Plain(PlainRow::Menu(Menu {
+            category_id,
+            content_pointer,
+            unknown,
+            visibility: *visibility,
+            sort_order,
+        })))?;
+    }
+    Ok(())
+}

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -87,6 +87,15 @@ pub struct Database<IO> {
     content: LazyDatabase,
 }
 
+/// Reference to a row stored in a page.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RowRef {
+    /// Index of the page that contains the row.
+    pub page_index: PageIndex,
+    /// Byte offset of the row inside the page data section.
+    pub row_offset: u16,
+}
+
 impl<R: Read + Seek> Database<R> {
     /// Opens a PDB database without writing back to disk.
     /// Still allows modifying data in memory.
@@ -198,6 +207,8 @@ impl<R: Read + Seek> Database<R> {
 }
 
 impl<RW: Read + Write + Seek> Database<RW> {
+    const PAGE_CHAIN_END: PageIndex = PageIndex(0x03FF_FFFF);
+
     /// Opens a PDB database for reading and writing.
     pub fn open(mut io: RW, db_type: DatabaseType) -> RekordcrateResult<Self> {
         let endian = Endian::Little;
@@ -221,6 +232,81 @@ impl<RW: Read + Write + Seek> Database<RW> {
     pub fn close(mut self) -> RekordcrateResult<()> {
         self.flush()?;
         Ok(())
+    }
+
+    /// Allocates a new empty data page and returns its page index.
+    fn alloc_data_page(&mut self, page_type: PageType) -> RekordcrateResult<PageIndex> {
+        let page_index = self.content.header.next_unused_page;
+        self.content.header.next_unused_page = PageIndex::try_from(page_index.0 + 1)?;
+
+        let page = Page::new_data(
+            self.content.header.page_size,
+            page_index,
+            page_type,
+            Self::PAGE_CHAIN_END,
+        );
+        self.content.pages.push(LazyPage::Loaded(page));
+
+        Ok(page_index)
+    }
+
+    /// Adds a row to the corresponding table, allocating a new page when needed.
+    pub fn add_row(&mut self, row: Row) -> RekordcrateResult<RowRef> {
+        let page_type = row.page_type()?;
+        let row_size = row.heap_bytes_required(());
+
+        let (_, table) = self
+            .content
+            .header
+            .find_table(page_type)
+            .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
+        let old_last_page = table.last_page;
+
+        {
+            let page = self.load_page(old_last_page)?;
+            let row_offset = page.header.used_size;
+            if let Some(insert) = page.allocate_row(row_size) {
+                insert(row);
+                return Ok(RowRef {
+                    page_index: old_last_page,
+                    row_offset,
+                });
+            }
+        }
+
+        let new_page_index = self.alloc_data_page(page_type)?;
+
+        match &mut self.content.pages[old_last_page.0 as usize - 1] {
+            LazyPage::Loaded(page) => {
+                page.header.next_page = new_page_index;
+                // Keep both copies of `next_page` in index pages in sync.
+                if let PageContent::Index(ref mut index_content) = page.content {
+                    index_content.header.next_page = new_page_index;
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        let (_, table) = self
+            .content
+            .header
+            .find_table_mut(page_type)
+            .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
+        table.last_page = new_page_index;
+
+        let page = self.load_page(new_page_index)?;
+        let row_offset = page.header.used_size;
+        let insert = page
+            .allocate_row(row_size)
+            .ok_or(RekordcrateError::IntegrityError(
+                "newly allocated page has no room for row",
+            ))?;
+        insert(row);
+
+        Ok(RowRef {
+            page_index: new_page_index,
+            row_offset,
+        })
     }
 }
 
@@ -314,6 +400,12 @@ impl<'db, R: Read + Seek> FallibleIterator for PageIterator<'db, R> {
 mod test {
     use super::*;
     use std::fs::File;
+    use std::io::Cursor;
+
+    fn open_test_db_rw() -> Database<Cursor<Vec<u8>>> {
+        let bytes = include_bytes!("../../data/pdb/num_rows/export.pdb");
+        Database::open(Cursor::new(bytes.to_vec()), DatabaseType::Plain).unwrap()
+    }
 
     #[test]
     fn test_pageiterator_safety() {
@@ -347,5 +439,77 @@ mod test {
         let _iter3 = db
             .iter_pages(PageType::Plain(PlainPageType::Tracks))
             .unwrap();
+    }
+
+    #[test]
+    fn test_allocate_page_updates_header_and_storage() {
+        let mut db = open_test_db_rw();
+        let next_unused_before = db.content.header.next_unused_page;
+        let page_count_before = db.content.pages.len();
+
+        let new_page_index = db
+            .alloc_data_page(PageType::Plain(PlainPageType::Keys))
+            .unwrap();
+
+        assert_eq!(new_page_index, next_unused_before);
+        assert_eq!(db.content.pages.len(), page_count_before + 1);
+        assert_eq!(
+            db.content.header.next_unused_page,
+            PageIndex::try_from(next_unused_before.0 + 1).unwrap()
+        );
+
+        let expected_next_page = Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END;
+        let new_page = db.load_page(new_page_index).unwrap();
+        assert_eq!(new_page.header.page_index, new_page_index);
+        assert_eq!(
+            new_page.header.page_type,
+            PageType::Plain(PlainPageType::Keys)
+        );
+        assert_eq!(new_page.header.next_page, expected_next_page);
+        assert!(matches!(new_page.content, PageContent::Data(_)));
+    }
+
+    #[test]
+    fn test_add_row_updates_index_inner_next_page_when_linking_new_page() {
+        let mut db = open_test_db_rw();
+        let tracks_page_type = PageType::Plain(PlainPageType::Tracks);
+
+        let (_, tracks_table) = db.content.header.find_table(tracks_page_type).unwrap();
+        let tracks_first_page = tracks_table.first_page;
+        let original_last_page = tracks_table.last_page;
+
+        let row = {
+            let page = db.load_page(original_last_page).unwrap();
+            let data_content = page.content.as_data().expect("expected data page");
+            data_content
+                .rows
+                .values()
+                .next()
+                .expect("expected existing row")
+                .clone()
+        };
+
+        {
+            let first_page = db.load_page(tracks_first_page).unwrap();
+            assert!(matches!(first_page.content, PageContent::Index(_)));
+        }
+
+        let (_, tracks_table_mut) = db.content.header.find_table_mut(tracks_page_type).unwrap();
+        tracks_table_mut.last_page = tracks_first_page;
+
+        let row_ref = db.add_row(row).unwrap();
+        assert_eq!(row_ref.row_offset, 0);
+
+        let first_page = db.load_page(tracks_first_page).unwrap();
+        assert_eq!(first_page.header.next_page, row_ref.page_index);
+        match &first_page.content {
+            PageContent::Index(index_content) => {
+                assert_eq!(index_content.header.next_page, row_ref.page_index);
+            }
+            _ => panic!("expected index page"),
+        }
+
+        let (_, tracks_table_after) = db.content.header.find_table(tracks_page_type).unwrap();
+        assert_eq!(tracks_table_after.last_page, row_ref.page_index);
     }
 }

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -207,7 +207,119 @@ impl<R: Read + Seek> Database<R> {
 }
 
 impl<RW: Read + Write + Seek> Database<RW> {
+    const DEFAULT_PAGE_SIZE: u32 = 4096;
     const PAGE_CHAIN_END: PageIndex = PageIndex(0x03FF_FFFF);
+
+    /// If `previous_page_index.next_page` is still the chain-end sentinel, relink it.
+    fn relink_if_chain_end(
+        &mut self,
+        previous_page_index: PageIndex,
+        current_page_index: PageIndex,
+    ) -> RekordcrateResult<()> {
+        let previous_page = self.load_page(previous_page_index)?;
+        if previous_page.header.next_page == Self::PAGE_CHAIN_END {
+            previous_page.header.next_page = current_page_index;
+            // Keep both copies of `next_page` in index pages in sync.
+            if let PageContent::Index(ref mut index_content) = previous_page.content {
+                index_content.header.next_page = current_page_index;
+            }
+        }
+        Ok(())
+    }
+
+    /// Finds the page that points to `current_page_index` in the table chain.
+    fn find_previous_page_in_chain(
+        &mut self,
+        first_page: PageIndex,
+        current_page_index: PageIndex,
+    ) -> RekordcrateResult<Option<PageIndex>> {
+        if first_page == current_page_index {
+            return Ok(None);
+        }
+
+        let mut cursor = first_page;
+        for _ in 0..=self.content.pages.len() {
+            let next_page = {
+                let page = self.load_page(cursor)?;
+                page.header.next_page
+            };
+
+            if next_page == current_page_index {
+                return Ok(Some(cursor));
+            }
+            if next_page == Self::PAGE_CHAIN_END {
+                return Ok(None);
+            }
+
+            cursor = next_page;
+        }
+
+        Err(RekordcrateError::IntegrityError(
+            "page chain traversal exceeded page count",
+        ))
+    }
+
+    /// Creates a new empty PDB database.
+    ///
+    /// Initializes each table with an index page followed by an empty data page.
+    pub fn create(
+        io: RW,
+        db_type: DatabaseType,
+        table_page_types: &[PageType],
+    ) -> RekordcrateResult<Self> {
+        let mut pages = Vec::with_capacity(table_page_types.len() * 2);
+        let mut tables = Vec::with_capacity(table_page_types.len());
+
+        let mut next_page = PageIndex::try_from(1)?;
+        for &page_type in table_page_types {
+            let index_page_index = next_page;
+            next_page = PageIndex::try_from(next_page.0 + 1)?;
+
+            let data_page_index = next_page;
+            next_page = PageIndex::try_from(next_page.0 + 1)?;
+
+            let mut index_page = Page::new_index(index_page_index, page_type, Self::PAGE_CHAIN_END);
+            if let PageContent::Index(ref mut index_content) = index_page.content {
+                index_content.header.next_page = Self::PAGE_CHAIN_END;
+            }
+            let data_page = Page::new_data(
+                Self::DEFAULT_PAGE_SIZE,
+                data_page_index,
+                page_type,
+                Self::PAGE_CHAIN_END,
+            );
+
+            tables.push(Table {
+                page_type,
+                empty_candidate: data_page_index.0,
+                first_page: index_page_index,
+                // Empty table: logical chain tail is the index page.
+                last_page: index_page_index,
+            });
+
+            pages.push(LazyPage::Loaded(index_page));
+            pages.push(LazyPage::Loaded(data_page));
+        }
+
+        let num_tables = table_page_types
+            .len()
+            .try_into()
+            .map_err(|_| RekordcrateError::IntegrityError("too many tables"))?;
+        let header = Header {
+            page_size: Self::DEFAULT_PAGE_SIZE,
+            num_tables,
+            next_unused_page: next_page,
+            unknown: 5,
+            sequence: 1,
+            tables,
+        };
+
+        Ok(Self {
+            io,
+            db_type,
+            content: LazyDatabase { header, pages },
+        })
+    }
 
     /// Opens a PDB database for reading and writing.
     pub fn open(mut io: RW, db_type: DatabaseType) -> RekordcrateResult<Self> {
@@ -254,38 +366,72 @@ impl<RW: Read + Write + Seek> Database<RW> {
     pub fn add_row(&mut self, row: Row) -> RekordcrateResult<RowRef> {
         let page_type = row.page_type()?;
         let row_size = row.heap_bytes_required(());
+        let mut pending_row = Some(row);
 
         let (_, table) = self
             .content
             .header
             .find_table(page_type)
             .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
+        let first_page = table.first_page;
         let old_last_page = table.last_page;
+        let empty_candidate = PageIndex::try_from(table.empty_candidate)?;
+        let mut target_page = old_last_page;
 
+        // For empty tables, use the preallocated empty-candidate data page first.
+        let can_use_empty_candidate =
+            if old_last_page == first_page && empty_candidate != first_page {
+                match self.load_page(empty_candidate) {
+                    Ok(page) => {
+                        page.header.page_type == page_type
+                            && matches!(page.content, PageContent::Data(_))
+                    }
+                    Err(_) => false,
+                }
+            } else {
+                false
+            };
+
+        if can_use_empty_candidate {
+            target_page = empty_candidate;
+        }
+
+        if old_last_page != target_page {
+            self.relink_if_chain_end(old_last_page, target_page)?;
+        } else if let Some(previous_page_index) =
+            self.find_previous_page_in_chain(first_page, target_page)?
         {
-            let page = self.load_page(old_last_page)?;
+            self.relink_if_chain_end(previous_page_index, target_page)?;
+        }
+
+        let inserted_row_ref = {
+            let page = self.load_page(target_page)?;
             let row_offset = page.header.used_size;
             if let Some(insert) = page.allocate_row(row_size) {
-                insert(row);
-                return Ok(RowRef {
-                    page_index: old_last_page,
+                insert(pending_row.take().expect("row should still be pending"));
+                Some(RowRef {
+                    page_index: target_page,
                     row_offset,
-                });
+                })
+            } else {
+                None
             }
+        };
+
+        if let Some(row_ref) = inserted_row_ref {
+            if old_last_page != target_page {
+                let (_, table) = self
+                    .content
+                    .header
+                    .find_table_mut(page_type)
+                    .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
+                table.last_page = target_page;
+            }
+            return Ok(row_ref);
         }
 
         let new_page_index = self.alloc_data_page(page_type)?;
-
-        match &mut self.content.pages[old_last_page.0 as usize - 1] {
-            LazyPage::Loaded(page) => {
-                page.header.next_page = new_page_index;
-                // Keep both copies of `next_page` in index pages in sync.
-                if let PageContent::Index(ref mut index_content) = page.content {
-                    index_content.header.next_page = new_page_index;
-                }
-            }
-            _ => unreachable!(),
-        }
+        self.relink_if_chain_end(target_page, new_page_index)?;
 
         let (_, table) = self
             .content
@@ -301,7 +447,7 @@ impl<RW: Read + Write + Seek> Database<RW> {
             .ok_or(RekordcrateError::IntegrityError(
                 "newly allocated page has no room for row",
             ))?;
-        insert(row);
+        insert(pending_row.expect("row should still be pending"));
 
         Ok(RowRef {
             page_index: new_page_index,
@@ -494,6 +640,17 @@ mod test {
             assert!(matches!(first_page.content, PageContent::Index(_)));
         }
 
+        {
+            let first_page = db.load_page(tracks_first_page).unwrap();
+            first_page.header.next_page = Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END;
+            match &mut first_page.content {
+                PageContent::Index(index_content) => {
+                    index_content.header.next_page = Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END;
+                }
+                _ => panic!("expected index page"),
+            }
+        }
+
         let (_, tracks_table_mut) = db.content.header.find_table_mut(tracks_page_type).unwrap();
         tracks_table_mut.last_page = tracks_first_page;
 
@@ -511,5 +668,93 @@ mod test {
 
         let (_, tracks_table_after) = db.content.header.find_table(tracks_page_type).unwrap();
         assert_eq!(tracks_table_after.last_page, row_ref.page_index);
+    }
+
+    #[test]
+    fn test_create_initializes_index_data_pairs() {
+        let table_page_types = [
+            PageType::Plain(PlainPageType::Tracks),
+            PageType::Plain(PlainPageType::Artists),
+        ];
+        let db = Database::create(
+            Cursor::new(Vec::new()),
+            DatabaseType::Plain,
+            &table_page_types,
+        )
+        .unwrap();
+
+        assert_eq!(db.content.header.page_size, 4096);
+        assert_eq!(db.content.header.num_tables, 2);
+        assert_eq!(
+            db.content.header.next_unused_page,
+            PageIndex::try_from(5).unwrap()
+        );
+        assert_eq!(db.content.pages.len(), 4);
+
+        let tracks_table = &db.content.header.tables[0];
+        assert_eq!(tracks_table.first_page, PageIndex::try_from(1).unwrap());
+        assert_eq!(tracks_table.last_page, PageIndex::try_from(1).unwrap());
+
+        let artists_table = &db.content.header.tables[1];
+        assert_eq!(artists_table.first_page, PageIndex::try_from(3).unwrap());
+        assert_eq!(artists_table.last_page, PageIndex::try_from(3).unwrap());
+
+        let tracks_index = match &db.content.pages[0] {
+            LazyPage::Loaded(page) => page,
+            LazyPage::NotLoaded => panic!("expected loaded page"),
+        };
+        assert!(matches!(tracks_index.content, PageContent::Index(_)));
+        assert_eq!(
+            tracks_index.header.next_page,
+            Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END
+        );
+        match &tracks_index.content {
+            PageContent::Index(index_content) => {
+                assert_eq!(
+                    index_content.header.next_page,
+                    Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END
+                );
+            }
+            _ => panic!("expected index page"),
+        }
+
+        let tracks_data = match &db.content.pages[1] {
+            LazyPage::Loaded(page) => page,
+            LazyPage::NotLoaded => panic!("expected loaded page"),
+        };
+        assert!(matches!(tracks_data.content, PageContent::Data(_)));
+        assert_eq!(
+            tracks_data.header.next_page,
+            Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END
+        );
+    }
+
+    #[test]
+    fn test_create_uses_chain_end_sentinel_for_all_new_data_pages() {
+        let table_page_types = [
+            PageType::Plain(PlainPageType::Tracks),
+            PageType::Plain(PlainPageType::Genres),
+            PageType::Plain(PlainPageType::Artists),
+        ];
+        let db = Database::create(
+            Cursor::new(Vec::new()),
+            DatabaseType::Plain,
+            &table_page_types,
+        )
+        .unwrap();
+
+        for page_entry in &db.content.pages {
+            let page = match page_entry {
+                LazyPage::Loaded(page) => page,
+                LazyPage::NotLoaded => panic!("expected loaded page"),
+            };
+
+            if matches!(page.content, PageContent::Data(_)) {
+                assert_eq!(
+                    page.header.next_page,
+                    Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END
+                );
+            }
+        }
     }
 }

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -215,7 +215,7 @@ impl<RW: Read + Write + Seek> Database<RW> {
         row_size.next_multiple_of(4)
     }
 
-    fn validate_track_row_size(track: &Track) -> RekordcrateResult<()> {
+    pub(crate) fn validate_track_row_size(track: &Track) -> RekordcrateResult<()> {
         let allocated = Self::allocated_row_size(track.heap_bytes_required(()));
         if allocated < Self::MIN_TRACK_ALLOCATED_SIZE {
             return Err(RekordcrateError::TrackRowTooSmall {

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -505,6 +505,15 @@ mod test {
         Database::open(Cursor::new(bytes.to_vec()), DatabaseType::Plain).unwrap()
     }
 
+    fn get_table_row_count<RowT: RowVariant>(
+        db: &mut Database<impl std::io::Read + std::io::Seek>,
+    ) -> usize {
+        db.iter_rows::<RowT>()
+            .expect("Failed to load rows")
+            .count()
+            .expect("Failed to count rows")
+    }
+
     #[test]
     fn test_pageiterator_safety() {
         // This was written when PageIterator used unsafe.
@@ -620,6 +629,75 @@ mod test {
 
         let (_, tracks_table_after) = db.content.header.find_table(tracks_page_type).unwrap();
         assert_eq!(tracks_table_after.last_page, row_ref.page_index);
+    }
+
+    #[test]
+    fn test_add_row_allocates_reachable_page() {
+        let mut data = Vec::from(include_bytes!("../../data/pdb/num_rows/export.pdb"));
+
+        // Capture state before modification (read-only snapshot via open_non_persistent).
+        let next_unused_before = {
+            let db =
+                Database::open_non_persistent(Cursor::new(&data[..]), DatabaseType::Plain).unwrap();
+            db.get_header().next_unused_page
+        };
+        let entries_before = get_table_row_count::<HistoryEntry>(
+            &mut Database::open_non_persistent(Cursor::new(&data[..]), DatabaseType::Plain)
+                .unwrap(),
+        );
+
+        let added = {
+            // Owned, growable buffer: allocating pages extends the DB past its original length.
+            let mut db = Database::open(Cursor::new(data.clone()), DatabaseType::Plain).unwrap();
+
+            // Grab an existing HistoryEntry to clone as a template for the appended rows.
+            let template_row = db
+                .iter_pages(PageType::Plain(PlainPageType::HistoryEntries))
+                .expect("failed to load HistoryEntries pages")
+                .find_map(|page| {
+                    Ok(page
+                        .content
+                        .as_data()
+                        .and_then(|d| d.rows.values().next().cloned()))
+                })
+                .expect("no HistoryEntry rows found")
+                .expect("expected a HistoryEntry row");
+
+            // The last page has 8 bytes free; a HistoryEntry is larger, so this forces allocation.
+            db.add_row(template_row.clone())
+                .expect("failed to append HistoryEntry row");
+            // A second append surely lands on the freshly allocated page (exercises link-following too).
+            db.add_row(template_row.clone())
+                .expect("failed to append second HistoryEntry row");
+
+            // Test-private field access: flush then move the cursor out without a public accessor.
+            db.flush().expect("failed to flush database");
+            data = db.io.into_inner();
+            2
+        };
+
+        // A new page should have been allocated.
+        let next_unused_after = {
+            let db =
+                Database::open_non_persistent(Cursor::new(&data[..]), DatabaseType::Plain).unwrap();
+            db.get_header().next_unused_page
+        };
+        assert!(
+            next_unused_after > next_unused_before,
+            "expected next_unused_page to advance after appending ({:?} -> {:?})",
+            next_unused_before,
+            next_unused_after
+        );
+
+        // Re-open read-only and confirm the appended rows are reachable through the chain.
+        let mut db = Database::open_non_persistent(Cursor::new(&data[..]), DatabaseType::Plain)
+            .expect("failed to reopen database");
+        let entries_after = get_table_row_count::<HistoryEntry>(&mut db);
+        assert_eq!(
+            entries_after,
+            entries_before + added,
+            "appended rows not reachable on re-read; the new page was allocated but never linked into the chain"
+        );
     }
 
     #[test]

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -209,6 +209,45 @@ impl<R: Read + Seek> Database<R> {
 impl<RW: Read + Write + Seek> Database<RW> {
     const DEFAULT_PAGE_SIZE: u32 = 4096;
     const PAGE_CHAIN_END: PageIndex = PageIndex(0x03FF_FFFF);
+    const MIN_TRACK_ALLOCATED_SIZE: u16 = 221;
+
+    fn allocated_row_size(row_size: u16) -> u16 {
+        row_size.next_multiple_of(4)
+    }
+
+    fn validate_track_row_size(track: &Track) -> RekordcrateResult<()> {
+        let allocated = Self::allocated_row_size(track.heap_bytes_required(()));
+        if allocated < Self::MIN_TRACK_ALLOCATED_SIZE {
+            return Err(RekordcrateError::TrackRowTooSmall {
+                track_id: track.id.0,
+                allocated,
+                minimum: Self::MIN_TRACK_ALLOCATED_SIZE,
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_all_track_rows(&mut self) -> RekordcrateResult<()> {
+        if self.db_type != DatabaseType::Plain {
+            return Ok(());
+        }
+
+        let mut pages = self.iter_pages(PageType::Plain(PlainPageType::Tracks))?;
+        while let Some(page) = pages.next()? {
+            let data = match &page.content {
+                PageContent::Data(data) => data,
+                PageContent::Index(_) => continue,
+            };
+
+            for row in data.rows.values() {
+                if let Row::Plain(PlainRow::Track(track)) = row {
+                    Self::validate_track_row_size(track)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 
     /// Points the previous page's `next_page` field at `current_page_index`.
     ///
@@ -301,6 +340,7 @@ impl<RW: Read + Write + Seek> Database<RW> {
 
     /// Flushes all changes to the underlying IO.
     pub fn flush(&mut self) -> RekordcrateResult<()> {
+        self.validate_all_track_rows()?;
         let endian = Endian::Little;
         self.io.seek(SeekFrom::Start(0))?;
         self.content.write_options(&mut self.io, endian, ())?;
@@ -352,6 +392,10 @@ impl<RW: Read + Write + Seek> Database<RW> {
 
     /// Adds a row to the corresponding table, allocating a new page when needed.
     pub fn add_row(&mut self, row: Row) -> RekordcrateResult<RowRef> {
+        if let Row::Plain(PlainRow::Track(track)) = &row {
+            Self::validate_track_row_size(track)?;
+        }
+
         let page_type = row.page_type()?;
         let row_size = row.heap_bytes_required(());
         let mut pending_row = Some(row);
@@ -497,6 +541,8 @@ impl<'db, R: Read + Seek> FallibleIterator for PageIterator<'db, R> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::pdb::string::DeviceSQLString;
+    use crate::util::MaybeCalculated;
     use std::fs::File;
     use std::io::Cursor;
 
@@ -785,6 +831,93 @@ mod test {
                     Database::<Cursor<Vec<u8>>>::PAGE_CHAIN_END
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_add_row_rejects_undersized_track_row() {
+        let table_page_types = [PageType::Plain(PlainPageType::Tracks)];
+        let mut db = Database::create(
+            Cursor::new(Vec::new()),
+            DatabaseType::Plain,
+            &table_page_types,
+        )
+        .unwrap();
+
+        let track = Track {
+            subtype: Subtype(0x24),
+            index_shift: 0x0000,
+            bitmask: 0,
+            sample_rate: 0,
+            composer_id: ArtistId(0),
+            file_size: 0,
+            unknown2: 0,
+            unknown3: 0,
+            unknown4: 0,
+            unknown5: 0,
+            artwork_id: ArtworkId(0),
+            key_id: KeyId(0),
+            bitrate: 0,
+            color: ColorIndex::None,
+            orig_artist_id: ArtistId(0),
+            disc_number: 0,
+            duration: 0,
+            file_type: FileType::Unknown,
+            label_id: LabelId(0),
+            genre_id: GenreId(0),
+            play_count: 0,
+            rating: 0,
+            remixer_id: ArtistId(0),
+            track_number: 0,
+            tempo: 0,
+            year: 0,
+            sample_depth: 0,
+            id: TrackId(1),
+            artist_id: ArtistId(1),
+            album_id: AlbumId(1),
+            offsets: OffsetArrayContainer {
+                offsets: MaybeCalculated::Calculated,
+                inner: TrackStrings {
+                    title: DeviceSQLString::new("Music").unwrap(),
+                    filename: DeviceSQLString::new("02 - Music.mp3").unwrap(),
+                    file_path: DeviceSQLString::new("/Contents/02 - Music.mp3").unwrap(),
+                    isrc: DeviceSQLString::empty(),
+                    lyricist: DeviceSQLString::empty(),
+                    unknown_string2: DeviceSQLString::empty(),
+                    unknown_string3: DeviceSQLString::empty(),
+                    unknown_string4: DeviceSQLString::empty(),
+                    unknown_string5: DeviceSQLString::empty(),
+                    unknown_string6: DeviceSQLString::empty(),
+                    unknown_string7: DeviceSQLString::empty(),
+                    unknown_string8: DeviceSQLString::empty(),
+                    message: DeviceSQLString::empty(),
+                    publish_track_information: DeviceSQLString::empty(),
+                    autoload_hotcues: DeviceSQLString::empty(),
+                    date_added: DeviceSQLString::empty(),
+                    release_date: DeviceSQLString::empty(),
+                    mix_name: DeviceSQLString::empty(),
+                    analyze_date: DeviceSQLString::empty(),
+                    analyze_path: DeviceSQLString::empty(),
+                    comment: DeviceSQLString::empty(),
+                },
+            },
+        };
+
+        let err = db
+            .add_row(Row::Plain(PlainRow::Track(track)))
+            .expect_err("expected undersized track row to be rejected");
+
+        match err {
+            RekordcrateError::TrackRowTooSmall {
+                track_id,
+                allocated,
+                minimum,
+            } => {
+                assert_eq!(track_id, 1);
+                assert!(allocated < minimum);
+                assert_eq!(minimum, 221);
+            }
+            other => panic!("unexpected error: {other:?}"),
         }
     }
 }

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -210,53 +210,20 @@ impl<RW: Read + Write + Seek> Database<RW> {
     const DEFAULT_PAGE_SIZE: u32 = 4096;
     const PAGE_CHAIN_END: PageIndex = PageIndex(0x03FF_FFFF);
 
-    /// If `previous_page_index.next_page` is still the chain-end sentinel, relink it.
-    fn relink_if_chain_end(
+    /// Points the previous page's `next_page` field at `current_page_index`.
+    ///
+    fn relink_chain_end(
         &mut self,
         previous_page_index: PageIndex,
         current_page_index: PageIndex,
     ) -> RekordcrateResult<()> {
         let previous_page = self.load_page(previous_page_index)?;
-        if previous_page.header.next_page == Self::PAGE_CHAIN_END {
-            previous_page.header.next_page = current_page_index;
-            // Keep both copies of `next_page` in index pages in sync.
-            if let PageContent::Index(ref mut index_content) = previous_page.content {
-                index_content.header.next_page = current_page_index;
-            }
+        previous_page.header.next_page = current_page_index;
+        // Keep both copies of `next_page` in index pages in sync.
+        if let PageContent::Index(ref mut index_content) = previous_page.content {
+            index_content.header.next_page = current_page_index;
         }
         Ok(())
-    }
-
-    /// Finds the page that points to `current_page_index` in the table chain.
-    fn find_previous_page_in_chain(
-        &mut self,
-        first_page: PageIndex,
-        current_page_index: PageIndex,
-    ) -> RekordcrateResult<Option<PageIndex>> {
-        if first_page == current_page_index {
-            return Ok(None);
-        }
-
-        let mut cursor = first_page;
-        for _ in 0..=self.content.pages.len() {
-            let next_page = {
-                let page = self.load_page(cursor)?;
-                page.header.next_page
-            };
-
-            if next_page == current_page_index {
-                return Ok(Some(cursor));
-            }
-            if next_page == Self::PAGE_CHAIN_END {
-                return Ok(None);
-            }
-
-            cursor = next_page;
-        }
-
-        Err(RekordcrateError::IntegrityError(
-            "page chain traversal exceeded page count",
-        ))
     }
 
     /// Creates a new empty PDB database.
@@ -362,6 +329,27 @@ impl<RW: Read + Write + Seek> Database<RW> {
         Ok(page_index)
     }
 
+    /// Tries to append a row to an existing page's heap. Returns `None` if the page
+    /// can't hold it (index page, or no free space).
+    fn try_insert_row(
+        &mut self,
+        page_index: PageIndex,
+        row_size: u16,
+        row: &mut Option<Row>,
+    ) -> RekordcrateResult<Option<RowRef>> {
+        let page = self.load_page(page_index)?;
+        let row_offset = page.header.used_size;
+        let insert = match page.allocate_row(row_size) {
+            Some(insert) => insert,
+            None => return Ok(None),
+        };
+        insert(row.take().expect("row should still be pending"));
+        Ok(Some(RowRef {
+            page_index,
+            row_offset,
+        }))
+    }
+
     /// Adds a row to the corresponding table, allocating a new page when needed.
     pub fn add_row(&mut self, row: Row) -> RekordcrateResult<RowRef> {
         let page_type = row.page_type()?;
@@ -373,65 +361,38 @@ impl<RW: Read + Write + Seek> Database<RW> {
             .header
             .find_table(page_type)
             .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
-        let first_page = table.first_page;
         let old_last_page = table.last_page;
         let empty_candidate = PageIndex::try_from(table.empty_candidate)?;
-        let mut target_page = old_last_page;
 
-        // For empty tables, use the preallocated empty-candidate data page first.
-        let can_use_empty_candidate =
-            if old_last_page == first_page && empty_candidate != first_page {
-                match self.load_page(empty_candidate) {
-                    Ok(page) => {
-                        page.header.page_type == page_type
-                            && matches!(page.content, PageContent::Data(_))
-                    }
-                    Err(_) => false,
-                }
-            } else {
-                false
-            };
-
-        if can_use_empty_candidate {
-            target_page = empty_candidate;
+        // Try the chain tail first.
+        if let Some(row_ref) = self.try_insert_row(old_last_page, row_size, &mut pending_row)? {
+            return Ok(row_ref);
         }
 
-        if old_last_page != target_page {
-            self.relink_if_chain_end(old_last_page, target_page)?;
-        } else if let Some(previous_page_index) =
-            self.find_previous_page_in_chain(first_page, target_page)?
+        // Tail was full or not a data page. Here we check if for some reason empty_candidate
+        // is a usable (i.e. has enough space) data page of the right type, and if so we use it.
+        if empty_candidate != old_last_page
+            && self.load_page(empty_candidate).is_ok_and(|page| {
+                page.header.page_type == page_type && matches!(page.content, PageContent::Data(_))
+            })
         {
-            self.relink_if_chain_end(previous_page_index, target_page)?;
-        }
-
-        let inserted_row_ref = {
-            let page = self.load_page(target_page)?;
-            let row_offset = page.header.used_size;
-            if let Some(insert) = page.allocate_row(row_size) {
-                insert(pending_row.take().expect("row should still be pending"));
-                Some(RowRef {
-                    page_index: target_page,
-                    row_offset,
-                })
-            } else {
-                None
-            }
-        };
-
-        if let Some(row_ref) = inserted_row_ref {
-            if old_last_page != target_page {
+            if let Some(row_ref) =
+                self.try_insert_row(empty_candidate, row_size, &mut pending_row)?
+            {
+                self.relink_chain_end(old_last_page, empty_candidate)?;
                 let (_, table) = self
                     .content
                     .header
                     .find_table_mut(page_type)
                     .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
-                table.last_page = target_page;
+                table.last_page = empty_candidate;
+                return Ok(row_ref);
             }
-            return Ok(row_ref);
         }
 
+        // No existing page fit: allocate a fresh one and link it onto the tail.
         let new_page_index = self.alloc_data_page(page_type)?;
-        self.relink_if_chain_end(target_page, new_page_index)?;
+        self.relink_chain_end(old_last_page, new_page_index)?;
 
         let (_, table) = self
             .content
@@ -440,19 +401,10 @@ impl<RW: Read + Write + Seek> Database<RW> {
             .ok_or_else(|| RekordcrateError::TableTypeNotPresent(page_type))?;
         table.last_page = new_page_index;
 
-        let page = self.load_page(new_page_index)?;
-        let row_offset = page.header.used_size;
-        let insert = page
-            .allocate_row(row_size)
+        self.try_insert_row(new_page_index, row_size, &mut pending_row)?
             .ok_or(RekordcrateError::IntegrityError(
                 "newly allocated page has no room for row",
-            ))?;
-        insert(pending_row.expect("row should still be pending"));
-
-        Ok(RowRef {
-            page_index: new_page_index,
-            row_offset,
-        })
+            ))
     }
 }
 

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -17,6 +17,20 @@
 //! - <https://djl-analysis.deepsymmetry.org/rekordbox-export-analysis/exports.html>
 //! - <https://github.com/henrybetts/Rekordbox-Decoding>
 //! - <https://github.com/flesniak/python-prodj-link/tree/master/prodj/pdblib>
+//!
+//! # Editing existing rows
+//!
+//! `Database::open` + `iter_rows` + `close` round-trips edits to disk, but each row is written
+//! back at its **original fixed offset** — the page heap is never repacked.
+//!
+//! - **Size-stable edits are safe.** Mutating a fixed-width scalar field leaves the row's
+//!   serialized length unchanged, so it lands cleanly in its slot.
+//! - **Length-changing string edits corrupt the page**, and this is *not* detected: a longer
+//!   string overwrites the next row, a shorter one leaves stale bytes. Grow or add strings by
+//!   appending a new row via [`Database::add_row`] or [`crate::DeviceExportWriter`] instead.
+//!
+//! `flush`/`close` only re-check the 221-byte minimum track row size; they cannot detect heap
+//! overflow.
 
 use super::*;
 use crate::util::{RekordcrateError, RekordcrateResult, TableIndex};

--- a/src/pdb/io.rs
+++ b/src/pdb/io.rs
@@ -223,6 +223,11 @@ impl<R: Read + Seek> Database<R> {
 impl<RW: Read + Write + Seek> Database<RW> {
     const DEFAULT_PAGE_SIZE: u32 = 4096;
     const PAGE_CHAIN_END: PageIndex = PageIndex(0x03FF_FFFF);
+    /// Minimum value for the allocated (4-byte-aligned) size of a Track row, in bytes. A CDJ-350
+    /// crashes entering its "TRACK" menu when any track row is shorter than this; 221 was the
+    /// smallest value found to avoid the crash (by trial and error). Enforced on [`Database::add_row`]
+    /// and [`Database::flush`]; see [`crate::device::writer::Track`] for how the high-level writer
+    /// pads `comment` to satisfy it.
     const MIN_TRACK_ALLOCATED_SIZE: u16 = 221;
 
     fn allocated_row_size(row_size: u16) -> u16 {

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -1101,7 +1101,7 @@ pub struct Album {
     unknown3: u32,
     /// The offsets and its data and the end of this row
     #[brw(args(20, subtype.get_offset_size(), ()))]
-    offsets: OffsetArrayContainer<TrailingName, 1>,
+    pub offsets: OffsetArrayContainer<TrailingName, 1>,
 }
 
 impl RowVariant for Album {

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -53,6 +53,9 @@ pub enum PdbError {
     /// Invalid flags were passed when creating an `IndexEntry`.
     #[error("Invalid index flags (expected max 3 bits): {0:#b}")]
     InvalidIndexFlags(u8),
+    /// A `Row::Unknown` has no associated page type.
+    #[error("Cannot determine page type of unknown row")]
+    UnknownRowType,
 }
 
 /// The type of the database were looking at.
@@ -2155,6 +2158,34 @@ pub enum Row {
 }
 
 impl Row {
+    /// Returns the page type this row belongs to.
+    pub fn page_type(&self) -> Result<PageType, PdbError> {
+        match self {
+            Row::Plain(plain_row) => Ok(PageType::Plain(match plain_row {
+                PlainRow::Album(_) => PlainPageType::Albums,
+                PlainRow::Artist(_) => PlainPageType::Artists,
+                PlainRow::Artwork(_) => PlainPageType::Artwork,
+                PlainRow::Color(_) => PlainPageType::Colors,
+                PlainRow::Genre(_) => PlainPageType::Genres,
+                PlainRow::HistoryPlaylist(_) => PlainPageType::HistoryPlaylists,
+                PlainRow::HistoryEntry(_) => PlainPageType::HistoryEntries,
+                PlainRow::Key(_) => PlainPageType::Keys,
+                PlainRow::Label(_) => PlainPageType::Labels,
+                PlainRow::PlaylistTreeNode(_) => PlainPageType::PlaylistTree,
+                PlainRow::PlaylistEntry(_) => PlainPageType::PlaylistEntries,
+                PlainRow::ColumnEntry(_) => PlainPageType::Columns,
+                PlainRow::Menu(_) => PlainPageType::Menu,
+                PlainRow::Track(_) => PlainPageType::Tracks,
+                PlainRow::History(_) => PlainPageType::History,
+            })),
+            Row::Ext(ext_row) => Ok(PageType::Ext(match ext_row {
+                ExtRow::Tag(_) => ExtPageType::Tag,
+                ExtRow::TrackTag(_) => ExtPageType::TrackTag,
+            })),
+            Row::Unknown => Err(PdbError::UnknownRowType),
+        }
+    }
+
     /// Attempt to convert this row into a reference to the given variant type.
     #[must_use]
     pub fn as_variant<T: RowVariant>(&self) -> Option<&T> {

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -375,6 +375,23 @@ pub struct IndexPageContent {
 }
 
 impl IndexPageContent {
+    /// Creates an empty index page content section.
+    #[must_use]
+    pub fn empty(page_index: PageIndex, next_page: PageIndex) -> Self {
+        Self {
+            header: IndexPageHeader {
+                unknown_a: 0,
+                unknown_b: 0,
+                next_offset: 0,
+                page_index,
+                next_page,
+                num_entries: 0,
+                first_empty: 0,
+            },
+            entries: vec![],
+        }
+    }
+
     fn total_entries(page_size: u32) -> usize {
         // The last 20 bytes in an index page are zeros.
         let entries_space = page_size - PageHeader::BINARY_SIZE - IndexPageHeader::BINARY_SIZE - 20;
@@ -564,6 +581,51 @@ pub struct Page {
 }
 
 impl Page {
+    /// Creates a new empty data page.
+    #[must_use]
+    pub fn new_data(
+        page_size: u32,
+        page_index: PageIndex,
+        page_type: PageType,
+        next_page: PageIndex,
+    ) -> Self {
+        let content = PageContent::Data(DataPageContent::empty());
+        let header = PageHeader {
+            page_index,
+            page_type,
+            next_page,
+            unknown1: 0,
+            unknown2: 0,
+            packed_row_counts: PackedRowCounts::new(),
+            page_flags: PageFlags::new_data_page(),
+            free_size: DataPageContent::page_heap_size(page_size)
+                .try_into()
+                .expect("page heap size must fit in u16"),
+            used_size: 0,
+        };
+
+        Self { header, content }
+    }
+
+    /// Creates a new empty index page.
+    #[must_use]
+    pub fn new_index(page_index: PageIndex, page_type: PageType, next_page: PageIndex) -> Self {
+        let content = PageContent::Index(IndexPageContent::empty(page_index, next_page));
+        let header = PageHeader {
+            page_index,
+            page_type,
+            next_page,
+            unknown1: 0,
+            unknown2: 0,
+            packed_row_counts: PackedRowCounts::new(),
+            page_flags: PageFlags::new_index_page(),
+            free_size: 0,
+            used_size: 0,
+        };
+
+        Self { header, content }
+    }
+
     /// Allocate space for a new row in the page heap and return a function to
     /// insert the row at the allocated offset. Returns `None` if there is
     /// insufficient free space in the page.
@@ -683,6 +745,21 @@ pub struct DataPageContent {
 }
 
 impl DataPageContent {
+    /// Creates an empty data page content section.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            header: DataPageHeader {
+                unknown5: 0,
+                unknown_not_num_rows_large: 0,
+                unknown6: 0,
+                unknown7: 0,
+            },
+            row_groups: vec![],
+            rows: BTreeMap::new(),
+        }
+    }
+
     fn page_heap_size(page_size: u32) -> u32 {
         page_size - PageHeader::BINARY_SIZE - DataPageHeader::BINARY_SIZE
     }

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -383,13 +383,13 @@ impl IndexPageContent {
     pub fn empty(page_index: PageIndex, next_page: PageIndex) -> Self {
         Self {
             header: IndexPageHeader {
-                unknown_a: 0,
-                unknown_b: 0,
+                unknown_a: 8191,
+                unknown_b: 8191,
                 next_offset: 0,
                 page_index,
                 next_page,
                 num_entries: 0,
-                first_empty: 0,
+                first_empty: 8191,
             },
             entries: vec![],
         }

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -19,6 +19,7 @@
 //! - <https://github.com/flesniak/python-prodj-link/tree/master/prodj/pdblib>
 
 pub mod bitfields;
+pub mod defaults;
 pub mod ext;
 pub mod io;
 pub mod offset_array;

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -1932,8 +1932,6 @@ impl Track {
     /// domain meaning. Stamps `subtype`/`bitmask`/`unknown5` and the observed-default
     /// strings so callers only set what they care about.
     #[must_use]
-    #[allow(dead_code)] // ponytail: used once the device writer lands; kept here so the
-                        // visibility refactor compiles standalone.
     pub(crate) fn default_row() -> Self {
         Self {
             subtype: Subtype(0x24),

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -40,7 +40,9 @@ use std::fmt;
 use crate::pdb::ext::{ExtPageType, ExtRow};
 use crate::pdb::offset_array::OffsetSize;
 use crate::pdb::string::DeviceSQLString;
-use crate::util::{parse_at_offsets, write_at_offsets, ColorIndex, FileType, TableIndex};
+use crate::util::{
+    parse_at_offsets, write_at_offsets, ColorIndex, FileType, MaybeCalculated, TableIndex,
+};
 use binrw::{binrw, BinRead, BinResult, BinWrite, Endian};
 use std::io::{Read, Seek, SeekFrom, Write};
 use thiserror::Error;
@@ -190,7 +192,6 @@ pub struct Table {
     pub page_type: PageType,
     /// Unknown field, maybe links to a chain of empty pages if the database is ever garbage
     /// collected (?).
-    #[allow(dead_code)]
     empty_candidate: u32,
     /// Index of the first page that belongs to this table.
     ///
@@ -769,8 +770,6 @@ impl DataPageContent {
     }
 }
 
-// Usage of PageHeapObject is coming in a future PR.
-#[allow(dead_code)]
 trait PageHeapObject {
     type Args<'a>;
 
@@ -1042,6 +1041,14 @@ impl PageHeapObject for LabelId {
 #[brw(little)]
 pub struct PlaylistTreeNodeId(pub u32);
 
+impl PlaylistTreeNodeId {
+    /// The root of the playlist tree. Nodes with this as their parent sit at the top level.
+    #[must_use]
+    pub const fn root() -> Self {
+        Self(0)
+    }
+}
+
 impl PageHeapObject for PlaylistTreeNodeId {
     type Args<'a> = ();
     fn heap_bytes_required(&self, _: ()) -> u16 {
@@ -1088,18 +1095,18 @@ impl OffsetArrayItems<1> for TrailingName {
 #[brw(little)]
 pub struct Album {
     /// Unknown field, usually `80 00`.
-    subtype: Subtype,
+    pub(crate) subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    index_shift: u16,
+    pub(crate) index_shift: u16,
     /// Unknown field.
-    unknown2: u32,
+    pub(crate) unknown2: u32,
     /// ID of the artist row associated with this row.
-    artist_id: ArtistId,
+    pub artist_id: ArtistId,
     /// ID of this row.
-    id: AlbumId,
+    pub id: AlbumId,
     /// Unknown field.
-    unknown3: u32,
+    pub(crate) unknown3: u32,
     /// The offsets and its data and the end of this row
     #[brw(args(20, subtype.get_offset_size(), ()))]
     pub offsets: OffsetArrayContainer<TrailingName, 1>,
@@ -1146,10 +1153,10 @@ impl PageHeapObject for Album {
 #[brw(little)]
 pub struct Artist {
     /// Determines if the `name` string is located at the 8-bit offset (0x60) or the 16-bit offset (0x64).
-    subtype: Subtype,
+    pub(crate) subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    index_shift: u16,
+    pub(crate) index_shift: u16,
     /// ID of this row.
     pub id: ArtistId,
     /// offsets at the row end
@@ -1195,9 +1202,9 @@ impl PageHeapObject for Artist {
 #[brw(little)]
 pub struct Artwork {
     /// ID of this row.
-    id: ArtworkId,
+    pub id: ArtworkId,
     /// Path to the album art file.
-    path: DeviceSQLString,
+    pub path: DeviceSQLString,
 }
 
 impl RowVariant for Artwork {
@@ -1284,9 +1291,9 @@ impl PageHeapObject for Color {
 #[brw(little)]
 pub struct Genre {
     /// ID of this row.
-    id: GenreId,
+    pub id: GenreId,
     /// Name of the genre.
-    name: DeviceSQLString,
+    pub name: DeviceSQLString,
 }
 
 impl RowVariant for Genre {
@@ -1411,22 +1418,22 @@ impl PageHeapObject for HistoryEntry {
 #[brw(little)]
 pub struct History {
     /// Subtype field, in this case usually `80 02` (hex) or `640` (decimal).
-    subtype: Subtype,
+    pub subtype: Subtype,
     /// Unknown field. I'm assuming this is the `index_shift` found in other row types.
-    index_shift: u16,
+    pub index_shift: u16,
     /// Tracks present in the database after this sync event.
-    num_tracks: u32,
+    pub num_tracks: u32,
     // Magic value, always zero.
     #[brw(magic = 0u32)]
     /// Sync date, e.g. "2022-02-02".
-    date: DeviceSQLString,
+    pub date: DeviceSQLString,
     // Magic value, always `7705` -> `0x1E19`.
     #[brw(magic = 0x1E19u16)]
     /// Format/protocol version string. In all known exports this is the string "1000".
     // We could make this magic, but for now this seems fine.
-    version: DeviceSQLString,
+    pub version: DeviceSQLString,
     /// Device or backup label. Can be empty.
-    label: DeviceSQLString,
+    pub label: DeviceSQLString,
 }
 
 impl PageHeapObject for History {
@@ -1470,11 +1477,11 @@ impl RowVariant for History {
 #[brw(little)]
 pub struct Key {
     /// ID of this row.
-    id: KeyId,
+    pub id: KeyId,
     /// Apparently a second copy of the row ID.
-    id2: u32,
+    pub id2: u32,
     /// Name of the key.
-    name: DeviceSQLString,
+    pub name: DeviceSQLString,
 }
 
 impl RowVariant for Key {
@@ -1513,9 +1520,9 @@ impl PageHeapObject for Key {
 #[brw(little)]
 pub struct Label {
     /// ID of this row.
-    id: LabelId,
+    pub id: LabelId,
     /// Name of the record label.
-    name: DeviceSQLString,
+    pub name: DeviceSQLString,
 }
 
 impl RowVariant for Label {
@@ -1555,13 +1562,13 @@ pub struct PlaylistTreeNode {
     /// ID of parent row of this row (which means that the parent is a folder).
     pub parent_id: PlaylistTreeNodeId,
     /// Unknown field.
-    unknown: u32,
+    pub(crate) unknown: u32,
     /// Sort order indicastor.
-    sort_order: u32,
+    pub sort_order: u32,
     /// ID of this row.
     pub id: PlaylistTreeNodeId,
     /// Indicates if the node is a folder. Non-zero if it's a leaf node, i.e. a playlist.
-    node_is_folder: u32,
+    pub(crate) node_is_folder: u32,
     /// Name of this node, as shown when navigating the menu.
     pub name: DeviceSQLString,
 }
@@ -1588,6 +1595,25 @@ impl PlaylistTreeNode {
     #[must_use]
     pub fn is_folder(&self) -> bool {
         self.node_is_folder > 0
+    }
+
+    /// Construct a node, encoding `is_folder` into the on-disk `node_is_folder` flag.
+    #[must_use]
+    pub fn new(
+        id: PlaylistTreeNodeId,
+        parent_id: PlaylistTreeNodeId,
+        name: DeviceSQLString,
+        is_folder: bool,
+        sort_order: u32,
+    ) -> Self {
+        Self {
+            parent_id,
+            unknown: 0,
+            sort_order,
+            id,
+            node_is_folder: u32::from(is_folder),
+            name,
+        }
     }
 }
 
@@ -1707,47 +1733,47 @@ impl PageHeapObject for ColumnEntry {
 /// String fields stored via the offset table in Track rows
 pub struct TrackStrings {
     /// International Standard Recording Code (ISRC), in mangled format.
-    isrc: DeviceSQLString,
+    pub(crate) isrc: DeviceSQLString,
     /// Lyricist of the track.
-    lyricist: DeviceSQLString,
+    pub(crate) lyricist: DeviceSQLString,
     /// Unknown string field containing a number.
     /// Appears to increment when the track is exported or modified in Rekordbox.
-    unknown_string2: DeviceSQLString,
+    pub(crate) unknown_string2: DeviceSQLString,
     /// Unknown string field containing a number.
-    unknown_string3: DeviceSQLString,
+    pub(crate) unknown_string3: DeviceSQLString,
     /// Unknown string field.
-    unknown_string4: DeviceSQLString,
+    pub(crate) unknown_string4: DeviceSQLString,
     /// Track "message", a field in the Rekordbox UI.
-    message: DeviceSQLString,
+    pub(crate) message: DeviceSQLString,
     /// "Publish track information" in Rekordbox, value is either "ON" or empty string.
     /// Appears related to the Stagehand product to control DJ equipment remotely.
-    publish_track_information: DeviceSQLString,
+    pub(crate) publish_track_information: DeviceSQLString,
     /// Determines if hotcues should be autoloaded. Value is either "ON" or empty string.
-    autoload_hotcues: DeviceSQLString,
+    pub(crate) autoload_hotcues: DeviceSQLString,
     /// Unknown string field (usually empty).
-    unknown_string5: DeviceSQLString,
+    pub(crate) unknown_string5: DeviceSQLString,
     /// Unknown string field (usually empty).
-    unknown_string6: DeviceSQLString,
+    pub(crate) unknown_string6: DeviceSQLString,
     /// Date when the track was added to the Rekordbox collection (YYYY-MM-DD).
-    date_added: DeviceSQLString,
+    pub(crate) date_added: DeviceSQLString,
     /// Date when the track was released (YYYY-MM-DD).
-    release_date: DeviceSQLString,
+    pub(crate) release_date: DeviceSQLString,
     /// Name of the remix (if any).
-    mix_name: DeviceSQLString,
+    pub(crate) mix_name: DeviceSQLString,
     /// Unknown string field (usually empty).
-    unknown_string7: DeviceSQLString,
+    pub(crate) unknown_string7: DeviceSQLString,
     /// File path of the track analysis file.
-    analyze_path: DeviceSQLString,
+    pub(crate) analyze_path: DeviceSQLString,
     /// Date when the track analysis was performed (YYYY-MM-DD).
-    analyze_date: DeviceSQLString,
+    pub(crate) analyze_date: DeviceSQLString,
     /// Track comment.
-    comment: DeviceSQLString,
+    pub(crate) comment: DeviceSQLString,
     /// Track title.
     pub title: DeviceSQLString,
     /// Unknown string field (usually empty).
-    unknown_string8: DeviceSQLString,
+    pub(crate) unknown_string8: DeviceSQLString,
     /// Name of the file.
-    filename: DeviceSQLString,
+    pub(crate) filename: DeviceSQLString,
     /// Path of the file.
     pub file_path: DeviceSQLString,
 }
@@ -1816,69 +1842,69 @@ impl OffsetArrayItems<21> for TrackStrings {
 #[brw(little)]
 pub struct Track {
     /// Unknown field, usually `24 00`.
-    subtype: Subtype,
+    pub(crate) subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    index_shift: u16,
+    pub(crate) index_shift: u16,
     /// Unknown field, called `bitmask` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x000c0700.
-    bitmask: u32,
+    pub(crate) bitmask: u32,
     /// Sample Rate in Hz.
-    sample_rate: u32,
+    pub(crate) sample_rate: u32,
     /// Composer of this track as artist row ID (non-zero if set).
-    composer_id: ArtistId,
+    pub(crate) composer_id: ArtistId,
     /// File size in bytes.
-    file_size: u32,
+    pub(crate) file_size: u32,
     /// Unknown field; observed values are effectively random.
-    unknown2: u32,
+    pub(crate) unknown2: u32,
     /// Unknown field; observed values: 19048, 64128, 31844.
     /// Appears to be the same for all tracks in a given DB.
-    unknown3: u16,
+    pub(crate) unknown3: u16,
     /// Unknown field; observed values: 30967, 1511, 9043.
     /// Appears to be the same for all tracks in a given DB.
-    unknown4: u16,
+    pub(crate) unknown4: u16,
     /// Artwork row ID for the cover art (non-zero if set),
-    artwork_id: ArtworkId,
+    pub(crate) artwork_id: ArtworkId,
     /// Key row ID for the cover art (non-zero if set).
-    key_id: KeyId,
+    pub(crate) key_id: KeyId,
     /// Artist row ID of the original performer (non-zero if set).
-    orig_artist_id: ArtistId,
+    pub(crate) orig_artist_id: ArtistId,
     /// Label row ID of the original performer (non-zero if set).
-    label_id: LabelId,
+    pub(crate) label_id: LabelId,
     /// Artist row ID of the remixer (non-zero if set).
-    remixer_id: ArtistId,
+    pub(crate) remixer_id: ArtistId,
     /// Bitrate of the track.
-    bitrate: u32,
+    pub(crate) bitrate: u32,
     /// Track number of the track.
-    track_number: u32,
+    pub(crate) track_number: u32,
     /// Track tempo in centi-BPM (= 1/100 BPM).
-    tempo: u32,
+    pub(crate) tempo: u32,
     /// Genre row ID for this track (non-zero if set).
-    genre_id: GenreId,
+    pub(crate) genre_id: GenreId,
     /// Album row ID for this track (non-zero if set).
-    album_id: AlbumId,
+    pub(crate) album_id: AlbumId,
     /// Artist row ID for this track (non-zero if set).
     pub artist_id: ArtistId,
     /// Row ID of this track (non-zero if set).
     pub id: TrackId,
     /// Disc number of this track (non-zero if set).
-    disc_number: u16,
+    pub(crate) disc_number: u16,
     /// Number of times this track was played.
-    play_count: u16,
+    pub(crate) play_count: u16,
     /// Year this track was released.
-    year: u16,
+    pub(crate) year: u16,
     /// Bits per sample of the track aduio file.
-    sample_depth: u16,
+    pub(crate) sample_depth: u16,
     /// Playback duration of this track in seconds (at normal speed).
-    duration: u16,
+    pub(crate) duration: u16,
     /// Unknown field, apparently always "0x29".
-    unknown5: u16,
+    pub(crate) unknown5: u16,
     /// Color row ID for this track (non-zero if set).
-    color: ColorIndex,
+    pub(crate) color: ColorIndex,
     /// User rating of this track (0 to 5 starts).
     pub rating: u8,
     /// Format of the file.
-    file_type: FileType,
+    pub(crate) file_type: FileType,
     /// offsets (strings) at row end
     #[brw(args(0x5C, subtype.get_offset_size(), ()))]
     pub offsets: OffsetArrayContainer<TrackStrings, 21>,
@@ -1897,6 +1923,81 @@ impl RowVariant for Track {
         match row {
             Row::Plain(PlainRow::Track(track)) => Some(track),
             _ => None,
+        }
+    }
+}
+
+impl Track {
+    /// Default values for the reverse-engineered serialization fields that have no
+    /// domain meaning. Stamps `subtype`/`bitmask`/`unknown5` and the observed-default
+    /// strings so callers only set what they care about.
+    #[must_use]
+    #[allow(dead_code)] // ponytail: used once the device writer lands; kept here so the
+                        // visibility refactor compiles standalone.
+    pub(crate) fn default_row() -> Self {
+        Self {
+            subtype: Subtype(0x24),
+            index_shift: 0,
+            bitmask: 788_224,
+            sample_rate: 0,
+            composer_id: ArtistId(0),
+            file_size: 0,
+            unknown2: 0,
+            unknown3: 0,
+            unknown4: 0,
+            artwork_id: ArtworkId(0),
+            key_id: KeyId(0),
+            orig_artist_id: ArtistId(0),
+            label_id: LabelId(0),
+            remixer_id: ArtistId(0),
+            bitrate: 0,
+            track_number: 0,
+            tempo: 0,
+            genre_id: GenreId(0),
+            album_id: AlbumId(0),
+            artist_id: ArtistId(0),
+            id: TrackId(0),
+            disc_number: 0,
+            play_count: 0,
+            year: 0,
+            sample_depth: 0,
+            duration: 0,
+            unknown5: 41,
+            color: ColorIndex::None,
+            rating: 0,
+            file_type: FileType::Unknown,
+            offsets: OffsetArrayContainer {
+                offsets: MaybeCalculated::Calculated,
+                inner: TrackStrings::default(),
+            },
+        }
+    }
+}
+
+impl Default for TrackStrings {
+    fn default() -> Self {
+        Self {
+            isrc: DeviceSQLString::empty(),
+            lyricist: DeviceSQLString::empty(),
+            unknown_string2: DeviceSQLString::new("1").unwrap(),
+            unknown_string3: DeviceSQLString::new("1").unwrap(),
+            unknown_string4: DeviceSQLString::empty(),
+            message: DeviceSQLString::empty(),
+            publish_track_information: DeviceSQLString::new("ON").unwrap(),
+            autoload_hotcues: DeviceSQLString::empty(),
+            unknown_string5: DeviceSQLString::empty(),
+            unknown_string6: DeviceSQLString::empty(),
+            date_added: DeviceSQLString::empty(),
+            release_date: DeviceSQLString::empty(),
+            mix_name: DeviceSQLString::empty(),
+            unknown_string7: DeviceSQLString::empty(),
+            analyze_path: DeviceSQLString::empty(),
+            analyze_date: DeviceSQLString::empty(),
+            comment: DeviceSQLString::empty(),
+            title: DeviceSQLString::empty(),
+            unknown_string8: DeviceSQLString::empty(),
+            filename: DeviceSQLString::empty(),
+            file_path: DeviceSQLString::empty(),
         }
     }
 }

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -158,7 +158,7 @@ pub trait RowVariant {
 #[binrw]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
 #[brw(little)]
-pub struct PageIndex(pub(crate) u32);
+pub struct PageIndex(pub u32);
 
 impl TryFrom<u32> for PageIndex {
     type Error = PdbError;
@@ -1095,18 +1095,18 @@ impl OffsetArrayItems<1> for TrailingName {
 #[brw(little)]
 pub struct Album {
     /// Unknown field, usually `80 00`.
-    pub(crate) subtype: Subtype,
+    pub subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    pub(crate) index_shift: u16,
+    pub index_shift: u16,
     /// Unknown field.
-    pub(crate) unknown2: u32,
+    pub unknown2: u32,
     /// ID of the artist row associated with this row.
     pub artist_id: ArtistId,
     /// ID of this row.
     pub id: AlbumId,
     /// Unknown field.
-    pub(crate) unknown3: u32,
+    pub unknown3: u32,
     /// The offsets and its data and the end of this row
     #[brw(args(20, subtype.get_offset_size(), ()))]
     pub offsets: OffsetArrayContainer<TrailingName, 1>,
@@ -1153,10 +1153,10 @@ impl PageHeapObject for Album {
 #[brw(little)]
 pub struct Artist {
     /// Determines if the `name` string is located at the 8-bit offset (0x60) or the 16-bit offset (0x64).
-    pub(crate) subtype: Subtype,
+    pub subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    pub(crate) index_shift: u16,
+    pub index_shift: u16,
     /// ID of this row.
     pub id: ArtistId,
     /// offsets at the row end
@@ -1242,15 +1242,15 @@ impl PageHeapObject for Artwork {
 #[brw(little)]
 pub struct Color {
     /// Unknown field.
-    unknown1: u32,
+    pub unknown1: u32,
     /// Unknown field.
-    unknown2: u8,
+    pub unknown2: u8,
     /// Numeric color ID
-    color: ColorIndex,
+    pub color: ColorIndex,
     /// Unknown field.
-    unknown3: u16,
+    pub unknown3: u16,
     /// User-defined name of the color.
-    name: DeviceSQLString,
+    pub name: DeviceSQLString,
 }
 
 impl RowVariant for Color {
@@ -1331,9 +1331,9 @@ impl PageHeapObject for Genre {
 #[brw(little)]
 pub struct HistoryPlaylist {
     /// ID of this row.
-    id: HistoryPlaylistId,
+    pub id: HistoryPlaylistId,
     /// Name of the playlist.
-    name: DeviceSQLString,
+    pub name: DeviceSQLString,
 }
 
 impl RowVariant for HistoryPlaylist {
@@ -1371,11 +1371,11 @@ impl PageHeapObject for HistoryPlaylist {
 #[brw(little)]
 pub struct HistoryEntry {
     /// ID of the track played at this position in the playlist.
-    track_id: TrackId,
+    pub track_id: TrackId,
     /// ID of the history playlist.
-    playlist_id: HistoryPlaylistId,
+    pub playlist_id: HistoryPlaylistId,
     /// Position within the playlist.
-    entry_index: u32,
+    pub entry_index: u32,
 }
 
 impl RowVariant for HistoryEntry {
@@ -1562,13 +1562,13 @@ pub struct PlaylistTreeNode {
     /// ID of parent row of this row (which means that the parent is a folder).
     pub parent_id: PlaylistTreeNodeId,
     /// Unknown field.
-    pub(crate) unknown: u32,
+    pub unknown: u32,
     /// Sort order indicastor.
     pub sort_order: u32,
     /// ID of this row.
     pub id: PlaylistTreeNodeId,
     /// Indicates if the node is a folder. Non-zero if it's a leaf node, i.e. a playlist.
-    pub(crate) node_is_folder: u32,
+    pub node_is_folder: u32,
     /// Name of this node, as shown when navigating the menu.
     pub name: DeviceSQLString,
 }
@@ -1682,14 +1682,14 @@ impl PageHeapObject for PlaylistEntry {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[brw(little)]
 pub struct ColumnEntry {
-    // Possibly the primary key, though I don't know if that would
-    // make sense as I don't think there are references to these
-    // rows anywhere else. This could be a stable ID to identify
-    // a category by in hardware (instead of by name).
-    id: u16,
-    // Maybe a bitfield containing infos on sort order and which
-    // columns are displayed.
-    unknown0: u16,
+    /// Possibly the primary key, though I don't know if that would
+    /// make sense as I don't think there are references to these
+    /// rows anywhere else. This could be a stable ID to identify
+    /// a category by in hardware (instead of by name).
+    pub id: u16,
+    /// Maybe a bitfield containing infos on sort order and which
+    /// columns are displayed.
+    pub unknown0: u16,
     /// TODO Contained string is prefixed by the "interlinear annotation"
     /// characters "\u{fffa}" and postfixed with "\u{fffb}" for some reason?!
     /// Contained strings are actually `DeviceSQLString::LongBody` even though
@@ -1733,47 +1733,47 @@ impl PageHeapObject for ColumnEntry {
 /// String fields stored via the offset table in Track rows
 pub struct TrackStrings {
     /// International Standard Recording Code (ISRC), in mangled format.
-    pub(crate) isrc: DeviceSQLString,
+    pub isrc: DeviceSQLString,
     /// Lyricist of the track.
-    pub(crate) lyricist: DeviceSQLString,
+    pub lyricist: DeviceSQLString,
     /// Unknown string field containing a number.
     /// Appears to increment when the track is exported or modified in Rekordbox.
-    pub(crate) unknown_string2: DeviceSQLString,
+    pub unknown_string2: DeviceSQLString,
     /// Unknown string field containing a number.
-    pub(crate) unknown_string3: DeviceSQLString,
+    pub unknown_string3: DeviceSQLString,
     /// Unknown string field.
-    pub(crate) unknown_string4: DeviceSQLString,
+    pub unknown_string4: DeviceSQLString,
     /// Track "message", a field in the Rekordbox UI.
-    pub(crate) message: DeviceSQLString,
+    pub message: DeviceSQLString,
     /// "Publish track information" in Rekordbox, value is either "ON" or empty string.
     /// Appears related to the Stagehand product to control DJ equipment remotely.
-    pub(crate) publish_track_information: DeviceSQLString,
+    pub publish_track_information: DeviceSQLString,
     /// Determines if hotcues should be autoloaded. Value is either "ON" or empty string.
-    pub(crate) autoload_hotcues: DeviceSQLString,
+    pub autoload_hotcues: DeviceSQLString,
     /// Unknown string field (usually empty).
-    pub(crate) unknown_string5: DeviceSQLString,
+    pub unknown_string5: DeviceSQLString,
     /// Unknown string field (usually empty).
-    pub(crate) unknown_string6: DeviceSQLString,
+    pub unknown_string6: DeviceSQLString,
     /// Date when the track was added to the Rekordbox collection (YYYY-MM-DD).
-    pub(crate) date_added: DeviceSQLString,
+    pub date_added: DeviceSQLString,
     /// Date when the track was released (YYYY-MM-DD).
-    pub(crate) release_date: DeviceSQLString,
+    pub release_date: DeviceSQLString,
     /// Name of the remix (if any).
-    pub(crate) mix_name: DeviceSQLString,
+    pub mix_name: DeviceSQLString,
     /// Unknown string field (usually empty).
-    pub(crate) unknown_string7: DeviceSQLString,
+    pub unknown_string7: DeviceSQLString,
     /// File path of the track analysis file.
-    pub(crate) analyze_path: DeviceSQLString,
+    pub analyze_path: DeviceSQLString,
     /// Date when the track analysis was performed (YYYY-MM-DD).
-    pub(crate) analyze_date: DeviceSQLString,
+    pub analyze_date: DeviceSQLString,
     /// Track comment.
-    pub(crate) comment: DeviceSQLString,
+    pub comment: DeviceSQLString,
     /// Track title.
     pub title: DeviceSQLString,
     /// Unknown string field (usually empty).
-    pub(crate) unknown_string8: DeviceSQLString,
+    pub unknown_string8: DeviceSQLString,
     /// Name of the file.
-    pub(crate) filename: DeviceSQLString,
+    pub filename: DeviceSQLString,
     /// Path of the file.
     pub file_path: DeviceSQLString,
 }
@@ -1842,69 +1842,69 @@ impl OffsetArrayItems<21> for TrackStrings {
 #[brw(little)]
 pub struct Track {
     /// Unknown field, usually `24 00`.
-    pub(crate) subtype: Subtype,
+    pub subtype: Subtype,
     /// Unknown field, called `index_shift` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x20 * row index.
-    pub(crate) index_shift: u16,
+    pub index_shift: u16,
     /// Unknown field, called `bitmask` by [@flesniak](https://github.com/flesniak).
     /// Appears to always be 0x000c0700.
-    pub(crate) bitmask: u32,
+    pub bitmask: u32,
     /// Sample Rate in Hz.
-    pub(crate) sample_rate: u32,
+    pub sample_rate: u32,
     /// Composer of this track as artist row ID (non-zero if set).
-    pub(crate) composer_id: ArtistId,
+    pub composer_id: ArtistId,
     /// File size in bytes.
-    pub(crate) file_size: u32,
+    pub file_size: u32,
     /// Unknown field; observed values are effectively random.
-    pub(crate) unknown2: u32,
+    pub unknown2: u32,
     /// Unknown field; observed values: 19048, 64128, 31844.
     /// Appears to be the same for all tracks in a given DB.
-    pub(crate) unknown3: u16,
+    pub unknown3: u16,
     /// Unknown field; observed values: 30967, 1511, 9043.
     /// Appears to be the same for all tracks in a given DB.
-    pub(crate) unknown4: u16,
+    pub unknown4: u16,
     /// Artwork row ID for the cover art (non-zero if set),
-    pub(crate) artwork_id: ArtworkId,
+    pub artwork_id: ArtworkId,
     /// Key row ID for the cover art (non-zero if set).
-    pub(crate) key_id: KeyId,
+    pub key_id: KeyId,
     /// Artist row ID of the original performer (non-zero if set).
-    pub(crate) orig_artist_id: ArtistId,
+    pub orig_artist_id: ArtistId,
     /// Label row ID of the original performer (non-zero if set).
-    pub(crate) label_id: LabelId,
+    pub label_id: LabelId,
     /// Artist row ID of the remixer (non-zero if set).
-    pub(crate) remixer_id: ArtistId,
+    pub remixer_id: ArtistId,
     /// Bitrate of the track.
-    pub(crate) bitrate: u32,
+    pub bitrate: u32,
     /// Track number of the track.
-    pub(crate) track_number: u32,
+    pub track_number: u32,
     /// Track tempo in centi-BPM (= 1/100 BPM).
-    pub(crate) tempo: u32,
+    pub tempo: u32,
     /// Genre row ID for this track (non-zero if set).
-    pub(crate) genre_id: GenreId,
+    pub genre_id: GenreId,
     /// Album row ID for this track (non-zero if set).
-    pub(crate) album_id: AlbumId,
+    pub album_id: AlbumId,
     /// Artist row ID for this track (non-zero if set).
     pub artist_id: ArtistId,
     /// Row ID of this track (non-zero if set).
     pub id: TrackId,
     /// Disc number of this track (non-zero if set).
-    pub(crate) disc_number: u16,
+    pub disc_number: u16,
     /// Number of times this track was played.
-    pub(crate) play_count: u16,
+    pub play_count: u16,
     /// Year this track was released.
-    pub(crate) year: u16,
+    pub year: u16,
     /// Bits per sample of the track aduio file.
-    pub(crate) sample_depth: u16,
+    pub sample_depth: u16,
     /// Playback duration of this track in seconds (at normal speed).
-    pub(crate) duration: u16,
+    pub duration: u16,
     /// Unknown field, apparently always "0x29".
-    pub(crate) unknown5: u16,
+    pub unknown5: u16,
     /// Color row ID for this track (non-zero if set).
-    pub(crate) color: ColorIndex,
+    pub color: ColorIndex,
     /// User rating of this track (0 to 5 starts).
     pub rating: u8,
     /// Format of the file.
-    pub(crate) file_type: FileType,
+    pub file_type: FileType,
     /// offsets (strings) at row end
     #[brw(args(0x5C, subtype.get_offset_size(), ()))]
     pub offsets: OffsetArrayContainer<TrackStrings, 21>,

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -40,9 +40,7 @@ use std::fmt;
 use crate::pdb::ext::{ExtPageType, ExtRow};
 use crate::pdb::offset_array::OffsetSize;
 use crate::pdb::string::DeviceSQLString;
-use crate::util::{
-    parse_at_offsets, write_at_offsets, ColorIndex, FileType, MaybeCalculated, TableIndex,
-};
+use crate::util::{parse_at_offsets, write_at_offsets, ColorIndex, FileType, TableIndex};
 use binrw::{binrw, BinRead, BinResult, BinWrite, Endian};
 use std::io::{Read, Seek, SeekFrom, Write};
 use thiserror::Error;
@@ -1923,79 +1921,6 @@ impl RowVariant for Track {
         match row {
             Row::Plain(PlainRow::Track(track)) => Some(track),
             _ => None,
-        }
-    }
-}
-
-impl Track {
-    /// Default values for the reverse-engineered serialization fields that have no
-    /// domain meaning. Stamps `subtype`/`bitmask`/`unknown5` and the observed-default
-    /// strings so callers only set what they care about.
-    #[must_use]
-    pub(crate) fn default_row() -> Self {
-        Self {
-            subtype: Subtype(0x24),
-            index_shift: 0,
-            bitmask: 788_224,
-            sample_rate: 0,
-            composer_id: ArtistId(0),
-            file_size: 0,
-            unknown2: 0,
-            unknown3: 0,
-            unknown4: 0,
-            artwork_id: ArtworkId(0),
-            key_id: KeyId(0),
-            orig_artist_id: ArtistId(0),
-            label_id: LabelId(0),
-            remixer_id: ArtistId(0),
-            bitrate: 0,
-            track_number: 0,
-            tempo: 0,
-            genre_id: GenreId(0),
-            album_id: AlbumId(0),
-            artist_id: ArtistId(0),
-            id: TrackId(0),
-            disc_number: 0,
-            play_count: 0,
-            year: 0,
-            sample_depth: 0,
-            duration: 0,
-            unknown5: 41,
-            color: ColorIndex::None,
-            rating: 0,
-            file_type: FileType::Unknown,
-            offsets: OffsetArrayContainer {
-                offsets: MaybeCalculated::Calculated,
-                inner: TrackStrings::default(),
-            },
-        }
-    }
-}
-
-impl Default for TrackStrings {
-    fn default() -> Self {
-        Self {
-            isrc: DeviceSQLString::empty(),
-            lyricist: DeviceSQLString::empty(),
-            unknown_string2: DeviceSQLString::new("1").unwrap(),
-            unknown_string3: DeviceSQLString::new("1").unwrap(),
-            unknown_string4: DeviceSQLString::empty(),
-            message: DeviceSQLString::empty(),
-            publish_track_information: DeviceSQLString::new("ON").unwrap(),
-            autoload_hotcues: DeviceSQLString::empty(),
-            unknown_string5: DeviceSQLString::empty(),
-            unknown_string6: DeviceSQLString::empty(),
-            date_added: DeviceSQLString::empty(),
-            release_date: DeviceSQLString::empty(),
-            mix_name: DeviceSQLString::empty(),
-            unknown_string7: DeviceSQLString::empty(),
-            analyze_path: DeviceSQLString::empty(),
-            analyze_date: DeviceSQLString::empty(),
-            comment: DeviceSQLString::empty(),
-            title: DeviceSQLString::empty(),
-            unknown_string8: DeviceSQLString::empty(),
-            filename: DeviceSQLString::empty(),
-            file_path: DeviceSQLString::empty(),
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,6 +15,17 @@ use crate::pdb::{PageIndex, PageType};
 use binrw::{binrw, file_ptr::IntoSeekFrom, BinRead, BinResult, BinWrite, Endian};
 use thiserror::Error;
 
+/// Which kind of row a foreign key points at. Used by
+/// [`RekordcrateError::UnknownForeignKey`] to identify the missing reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForeignKeyKind {
+    /// A track row (`add_track_to_playlist` referenced an unknown track id).
+    Track,
+    /// A playlist-tree node (`create_playlist`/`create_playlist_folder` referenced an unknown
+    /// parent id, or a call referenced an unknown playlist id).
+    PlaylistNode,
+}
+
 /// Enumerates errors returned by this library.
 #[derive(Error, Debug)]
 #[non_exhaustive]
@@ -77,6 +88,26 @@ pub enum RekordcrateError {
     #[cfg(feature = "xml")]
     #[error(transparent)]
     XmlDeserializationFailed(#[from] quick_xml::DeError),
+
+    /// A row referenced a foreign key (track id, playlist node id, ...) that does not exist.
+    #[error("unknown foreign key: {kind:?} id={id}")]
+    UnknownForeignKey {
+        /// Which kind of referenced row was missing.
+        kind: ForeignKeyKind,
+        /// The id that did not resolve to a row.
+        id: u32,
+    },
+
+    /// Artwork image processing failed (decoding, resizing, or writing). Only constructed under the
+    /// `artwork` feature, but the variant is unconditional so it does not leak the `image` crate
+    /// into the public error type.
+    #[error("artwork error for {path:?}: {message}")]
+    ArtworkError {
+        /// Path of the artwork file involved (source or destination).
+        path: std::path::PathBuf,
+        /// Human-readable detail from the underlying failure.
+        message: String,
+    },
 }
 
 /// Type alias for results where the error is a `RekordcrateError`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -24,6 +24,8 @@ pub enum ForeignKeyKind {
     /// A playlist-tree node (`create_playlist`/`create_playlist_folder` referenced an unknown
     /// parent id, or a call referenced an unknown playlist id).
     PlaylistNode,
+    /// A tag category (`add_tags_to_track` referenced an unknown category id).
+    TagCategory,
 }
 
 /// Enumerates errors returned by this library.

--- a/src/util.rs
+++ b/src/util.rs
@@ -192,6 +192,65 @@ pub enum FileType {
     Other(u16),
 }
 
+/// Track rating on a 0–5 star scale. The PDB encodes this as a raw byte `0..=5`, confirmed against
+/// a real Rekordbox export (not the XML's `0/51/102/153/204/255`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Rating {
+    /// 0 stars (unrated).
+    #[default]
+    Zero,
+    /// 1 star.
+    One,
+    /// 2 stars.
+    Two,
+    /// 3 stars.
+    Three,
+    /// 4 stars.
+    Four,
+    /// 5 stars.
+    Five,
+}
+
+impl Rating {
+    /// Construct from a raw star count. Values above 5 clamp to [`Rating::Five`].
+    #[must_use]
+    pub fn from_stars(n: u8) -> Self {
+        match n.min(5) {
+            0 => Self::Zero,
+            1 => Self::One,
+            2 => Self::Two,
+            3 => Self::Three,
+            4 => Self::Four,
+            _ => Self::Five,
+        }
+    }
+
+    /// The raw byte written to the PDB (`0..=5`).
+    #[must_use]
+    pub fn to_byte(self) -> u8 {
+        match self {
+            Self::Zero => 0,
+            Self::One => 1,
+            Self::Two => 2,
+            Self::Three => 3,
+            Self::Four => 4,
+            Self::Five => 5,
+        }
+    }
+}
+
+impl From<Rating> for u8 {
+    fn from(rating: Rating) -> u8 {
+        rating.to_byte()
+    }
+}
+
+impl From<u8> for Rating {
+    fn from(n: u8) -> Self {
+        Self::from_stars(n)
+    }
+}
+
 /// Parses a sequence of values with `BinRead` from the offsets provided by the iterator.
 pub(crate) fn parse_at_offsets<Offset, Value, T, Args, It, Reader>(
     it: It,

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,6 +31,19 @@ pub enum RekordcrateError {
     #[error("failed integrity constraint: {0}")]
     IntegrityError(&'static str),
 
+    /// Track row allocation is too small for robust CDJ compatibility.
+    #[error(
+        "track row id={track_id} allocates {allocated} bytes, minimum supported is {minimum} bytes"
+    )]
+    TrackRowTooSmall {
+        /// Track ID of the invalid row.
+        track_id: u32,
+        /// Allocated row size in bytes (4-byte aligned).
+        allocated: u16,
+        /// Minimum supported row size in bytes.
+        minimum: u16,
+    },
+
     /// Represents an `std::io::Error`.
     #[error(transparent)]
     IOError(#[from] std::io::Error),

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,9 +23,10 @@ pub enum RekordcrateError {
     #[error(transparent)]
     StringError(#[from] StringError),
 
-    /// Represents a failure to parse input.
+    /// Represents a failure to read or write a binary format via `binrw` (covers both parse and
+    /// serialization errors).
     #[error(transparent)]
-    ParseError(#[from] binrw::Error),
+    BinrwError(#[from] binrw::Error),
 
     /// Represents a failure to validate a constraint.
     #[error("failed integrity constraint: {0}")]


### PR DESCRIPTION
Until now, the API allowed users to read device exports. This PR restructures the `device` module and adds an (opinionated) high-level API to build a complete (and hopefully, working) export from scratch, as well as easy access to the underlying plain and ext databases via `device::Layout` methods when used alongside `pdb::io::Database::open`.

Example:

```rust
use rekordcrate::{DeviceExportWriter, Track};

let mut export = DeviceExportWriter::create("/mnt/usb")?;
let track = Track {
    title: "Song".into(),
    artist: "Artist".into(),
    file_path: "/Contents/Artist - Song.mp3".into(),
    ..Track::default()
};
export.add_track(&track)?;
export.close()?;
```

`add_track(&Track) -> AddTrackOutcome` resolves artists/albums/genres/keys/labels into deduplicated PDB rows. It returns the existing track id if `file_path` already exists, whether it was added earlier this session or read back by `open()`. 

Playlists (`create_playlist_folder`, `create_playlist`, `add_track_to_playlist`) enforce folder-vs-playlist roles and reject ids that don't resolve to an existing node or track.

Tag categories and track tags are also supported via `create_tag_category` and `add_tags_to_track`.

`Track` is a new struct that contains nothing of the inner intricacies of the actual `pdb` format: it has plain `String` fields, `rating` is an enum, `tempo` is a float, key-names are converted to a common format to avoid duplicates... A special quirk that I haven't mentioned before is that my CDJ-350 player would crash when entering the "TRACK" menu if there was any rows shorter than a specific number of bytes. After trial and error, I settled on a minimum of 221 bytes per track row (quite random, I know) and so the writer pads the `comment` field to achieve that minimum size.

`Artwork` is behind the artwork feature (given that it adds the `image` dependency): `add_track` copies from `artwork_path` into PIONEER/Artwork/ under under Rekordbox's bucketed folder layout (20 per folder), resized to 80×80 + 240×240. Without the feature we do not copy, and thus the job is left to the user.

**Limitations**: this is append-only: we still have no high-level way to do in-place modifications (imo just rebuilding the entire database from scratch is cheap so many users will just do that anyway). We also do not copy files into their destinations: users are expected to copy the file first, then fill `file_path` with the destination. There's also no way to generate `anlz` files (sadly my CDJ-350 doesn't seem to read or generate those at all so I would have no way to test that... unless I buy more hardware hehe).

Regarding the low-level read/write/edit access, I also made `pdb` struct fields public to facilitate it. 