### PR TITLE
feat(pdb): type opaque table 7 and 18 rows

### DIFF
--- a/src/pdb/bitfields.rs
+++ b/src/pdb/bitfields.rs
@@ -16,7 +16,7 @@ use modular_bitfield::prelude::*;
 #[cfg(feature = "json")]
 use serde::{Serialize, Serializer};
 
-use crate::pdb::RowGroup;
+use crate::pdb::{PageHeapObject, RowGroup};
 
 /// Packed field found in the page header containing:
 /// - number of used row offsets in the page (13 bits).
@@ -140,6 +140,124 @@ impl PageFlags {
     }
 }
 
+/// Opaque flag word found in table-7 rows of `exportExt.pdb`.
+#[bitfield(bits = 32)]
+#[derive(BinRead, BinWrite, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
+#[br(little, map = Self::from_bytes)]
+#[bw(little, map = |x: &Self| x.into_bytes())]
+pub struct Unknown7Flags0 {
+    pub unknown0: bool,
+    pub reserved1_12: B12,
+    pub unknown13: bool,
+    pub reserved14_25: B12,
+    pub unknown26: bool,
+    pub reserved27_28: B2,
+    pub unknown29: bool,
+    pub reserved30_31: B2,
+}
+
+impl PageHeapObject for Unknown7Flags0 {
+    type Args<'a> = ();
+    fn heap_bytes_required(&self, _: ()) -> u16 {
+        std::mem::size_of::<u32>() as u16
+    }
+}
+
+impl Unknown7Flags0 {
+    /// Observed canonical value in known `exportExt.pdb` files.
+    pub fn canonical() -> Self {
+        Self::new()
+            .with_unknown0(true)
+            .with_unknown13(true)
+            .with_unknown26(true)
+            .with_unknown29(true)
+    }
+}
+
+/// Opaque flag word found in table-7 rows of `exportExt.pdb`.
+#[bitfield(bits = 32)]
+#[derive(BinRead, BinWrite, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
+#[br(little, map = Self::from_bytes)]
+#[bw(little, map = |x: &Self| x.into_bytes())]
+pub struct Unknown7Flags1 {
+    pub reserved0: B1,
+    pub unknown1: bool,
+    pub unknown2: bool,
+    pub reserved3: B1,
+    pub unknown4: bool,
+    pub reserved5_6: B2,
+    pub unknown7: bool,
+    pub unknown8: bool,
+    pub unknown9: bool,
+    pub unknown10: bool,
+    pub unknown11: bool,
+    pub reserved12_17: B6,
+    pub unknown18: bool,
+    pub unknown19: bool,
+    pub unknown20: bool,
+    pub unknown21: bool,
+    pub reserved22_31: B10,
+}
+
+impl PageHeapObject for Unknown7Flags1 {
+    type Args<'a> = ();
+    fn heap_bytes_required(&self, _: ()) -> u16 {
+        std::mem::size_of::<u32>() as u16
+    }
+}
+
+impl Unknown7Flags1 {
+    /// Observed canonical value in known `exportExt.pdb` files.
+    pub fn canonical() -> Self {
+        Self::new()
+            .with_unknown1(true)
+            .with_unknown2(true)
+            .with_unknown4(true)
+            .with_unknown7(true)
+            .with_unknown8(true)
+            .with_unknown9(true)
+            .with_unknown10(true)
+            .with_unknown11(true)
+            .with_unknown18(true)
+            .with_unknown19(true)
+            .with_unknown20(true)
+            .with_unknown21(true)
+    }
+}
+
+/// Opaque flag word found in table-7 rows of `exportExt.pdb`.
+#[bitfield(bits = 32)]
+#[derive(BinRead, BinWrite, Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
+#[br(little, map = Self::from_bytes)]
+#[bw(little, map = |x: &Self| x.into_bytes())]
+pub struct Unknown7Flags2 {
+    pub reserved0_7: B8,
+    pub unknown8: bool,
+    pub unknown9: bool,
+    pub unknown10: bool,
+    pub reserved11_31: B21,
+}
+
+impl PageHeapObject for Unknown7Flags2 {
+    type Args<'a> = ();
+    fn heap_bytes_required(&self, _: ()) -> u16 {
+        std::mem::size_of::<u32>() as u16
+    }
+}
+
+impl Unknown7Flags2 {
+    /// Observed canonical value in known `exportExt.pdb` files.
+    pub fn canonical() -> Self {
+        Self::new()
+            .with_unknown8(true)
+            .with_unknown9(true)
+            .with_unknown10(true)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -157,5 +275,21 @@ mod test {
 
         flags.set_contains_deleted(true);
         assert_eq!(flags.into_bytes(), [0x34]);
+    }
+
+    #[test]
+    fn test_unknown7_flag_words() {
+        assert_eq!(
+            Unknown7Flags0::canonical().into_bytes(),
+            [0x01, 0x20, 0x00, 0x24]
+        );
+        assert_eq!(
+            Unknown7Flags1::canonical().into_bytes(),
+            [0x96, 0x0f, 0x3c, 0x00]
+        );
+        assert_eq!(
+            Unknown7Flags2::canonical().into_bytes(),
+            [0x00, 0x07, 0x00, 0x00]
+        );
     }
 }

--- a/src/pdb/mod.rs
+++ b/src/pdb/mod.rs
@@ -24,7 +24,7 @@ pub mod io;
 pub mod offset_array;
 pub mod string;
 
-use bitfields::{PackedRowCounts, PageFlags};
+use bitfields::{PackedRowCounts, PageFlags, Unknown7Flags0, Unknown7Flags1, Unknown7Flags2};
 use offset_array::{OffsetArrayContainer, OffsetArrayItems};
 
 #[cfg(test)]
@@ -83,6 +83,9 @@ pub enum PageType {
     /// Pagetypes present in `exportExt.pdb` files.
     Ext(ExtPageType),
     /// Unknown page type.
+    ///
+    /// The fixed payloads used by plain table 18 and `exportExt.pdb` table 7 are represented by
+    /// [`Unknown18Row`] and [`Unknown7Row`], respectively; other unknown page types remain opaque.
     Unknown(u32),
 }
 
@@ -705,9 +708,12 @@ impl DataPageContent {
     }
 }
 
-// Usage of PageHeapObject is coming in a future PR.
+/// Accounts for the bytes a row occupies in a data page's heap.
+///
+/// This is crate-visible because row implementations live in the `ext` and `bitfields` modules,
+/// while the trait itself is an implementation detail of PDB page allocation.
 #[allow(dead_code)]
-trait PageHeapObject {
+pub(crate) trait PageHeapObject {
     type Args<'a>;
 
     /// Required page heap space in bytes to store the object.
@@ -1996,6 +2002,171 @@ impl RowVariant for Menu {
     }
 }
 
+/// Fixed 8-byte rows found in `Unknown(18)` pages of every known plain export.
+///
+/// The first two fields line up with `ColumnEntry.id` values and a stable ordering across the
+/// fixture set. The final two words remain only partially understood, so they are retained as
+/// opaque values rather than discarded.
+#[binrw]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
+#[brw(little)]
+pub struct Unknown18Row {
+    /// Matches a `ColumnEntry.id` in known exports.
+    pub column_id: u16,
+    /// Stable ordering value within the fixed table-18 seed rows.
+    pub sort_order: u16,
+    /// Opaque tag value.
+    pub tag: u16,
+    /// Reserved / unknown trailing word.
+    pub reserved: u16,
+}
+
+impl Unknown18Row {
+    /// Create a new table-18 row.
+    #[must_use]
+    pub const fn new(column_id: u16, sort_order: u16, tag: u16, reserved: u16) -> Self {
+        Self {
+            column_id,
+            sort_order,
+            tag,
+            reserved,
+        }
+    }
+}
+
+impl PageHeapObject for Unknown18Row {
+    type Args<'a> = ();
+    fn heap_bytes_required(&self, _: ()) -> u16 {
+        std::mem::size_of::<Self>() as u16
+    }
+}
+
+impl RowVariant for Unknown18Row {
+    const PAGE_TYPE: PageType = PageType::Unknown(18);
+
+    fn from_row(row: &Row) -> Option<&Self> {
+        match row {
+            Row::Unknown18(row) => Some(row),
+            _ => None,
+        }
+    }
+
+    fn from_row_mut(row: &mut Row) -> Option<&mut Self> {
+        match row {
+            Row::Unknown18(row) => Some(row),
+            _ => None,
+        }
+    }
+}
+
+/// Fixed 60-byte rows found in table 7 of known `exportExt.pdb` files.
+///
+/// Several fields are still opaque, but naming the page and table pointers makes the record useful
+/// to callers while preserving every byte for round-trip serialization.
+#[binrw]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "json", derive(Serialize))]
+#[brw(little)]
+pub struct Unknown7Row {
+    /// Opaque leading value.
+    pub reserved0: u32,
+    /// Points at the table's current data page.
+    pub data_page: u32,
+    /// Matches the containing table ID in known exports.
+    pub table_id: u32,
+    /// Points at the table's current empty-candidate page.
+    pub empty_candidate_page: u32,
+    /// Opaque state value.
+    pub state: u32,
+    /// Reserved / unknown.
+    pub reserved1: u32,
+    /// Opaque flags word.
+    pub flags0: Unknown7Flags0,
+    /// Opaque flags word.
+    pub flags1: Unknown7Flags1,
+    /// Opaque version / count field.
+    pub version: u32,
+    /// Reserved / unknown.
+    pub reserved2: u32,
+    /// Opaque bitmask value.
+    pub flags2: Unknown7Flags2,
+    /// Reserved / unknown.
+    pub reserved3: u32,
+    /// Reserved / unknown.
+    pub reserved4: u32,
+    /// Reserved / unknown.
+    pub reserved5: u32,
+    /// Reserved / unknown.
+    pub reserved6: u32,
+}
+
+impl Unknown7Row {
+    /// Create a new table-7 row for `exportExt.pdb`.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
+    pub const fn new(
+        reserved0: u32,
+        data_page: u32,
+        table_id: u32,
+        empty_candidate_page: u32,
+        state: u32,
+        reserved1: u32,
+        flags0: Unknown7Flags0,
+        flags1: Unknown7Flags1,
+        version: u32,
+        reserved2: u32,
+        flags2: Unknown7Flags2,
+        reserved3: u32,
+        reserved4: u32,
+        reserved5: u32,
+        reserved6: u32,
+    ) -> Self {
+        Self {
+            reserved0,
+            data_page,
+            table_id,
+            empty_candidate_page,
+            state,
+            reserved1,
+            flags0,
+            flags1,
+            version,
+            reserved2,
+            flags2,
+            reserved3,
+            reserved4,
+            reserved5,
+            reserved6,
+        }
+    }
+}
+
+impl PageHeapObject for Unknown7Row {
+    type Args<'a> = ();
+    fn heap_bytes_required(&self, _: ()) -> u16 {
+        std::mem::size_of::<Self>() as u16
+    }
+}
+
+impl RowVariant for Unknown7Row {
+    const PAGE_TYPE: PageType = PageType::Unknown(7);
+
+    fn from_row(row: &Row) -> Option<&Self> {
+        match row {
+            Row::Unknown7(row) => Some(row),
+            _ => None,
+        }
+    }
+
+    fn from_row_mut(row: &mut Row) -> Option<&mut Self> {
+        match row {
+            Row::Unknown7(row) => Some(row),
+            _ => None,
+        }
+    }
+}
+
 /// A table row contains the actual data.
 #[binrw]
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -2121,8 +2292,16 @@ pub enum Row {
         }))]
         ExtRow,
     ),
-    /// The row format (and also its size) is unknown, which means it can't be parsed.
-    #[br(pre_assert(matches!(page_type, PageType::Unknown(_))))]
+    /// Typed row for the fixed payload found in `exportExt.pdb` table 7.
+    #[br(pre_assert(page_type == PageType::Unknown(7)))]
+    Unknown7(Unknown7Row),
+    /// Typed row for the fixed payload found in plain-export table 18.
+    #[br(pre_assert(page_type == PageType::Unknown(18)))]
+    Unknown18(Unknown18Row),
+    /// A row whose format and size are unknown, so it cannot be parsed.
+    #[br(pre_assert(matches!(page_type, PageType::Unknown(_))
+        && page_type != PageType::Unknown(7)
+        && page_type != PageType::Unknown(18)))]
     Unknown,
 }
 
@@ -2145,6 +2324,8 @@ impl PageHeapObject for Row {
         match self {
             Row::Plain(plain_row) => plain_row.heap_bytes_required(()),
             Row::Ext(ext_row) => ext_row.heap_bytes_required(()),
+            Row::Unknown7(row) => row.heap_bytes_required(()),
+            Row::Unknown18(row) => row.heap_bytes_required(()),
             Row::Unknown => panic!("Unable to determine required bytes for unknown row type"),
         }
     }

--- a/tests/test_pdb_unknown_rows.rs
+++ b/tests/test_pdb_unknown_rows.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Robin McCorkell <robin@mccorkell.me.uk>
+//
+// This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy
+// of the MPL was not distributed with this file, You can obtain one at
+// http://mozilla.org/MPL/2.0/.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use binrw::{BinRead, BinWrite, Endian};
+use fallible_iterator::FallibleIterator;
+use rekordcrate::pdb::bitfields::{Unknown7Flags0, Unknown7Flags1, Unknown7Flags2};
+use rekordcrate::pdb::io::Database;
+use rekordcrate::pdb::*;
+use std::io::Cursor;
+
+#[test]
+fn parses_plain_table_18_rows() {
+    let data = include_bytes!("../data/complete_export/demo_tracks/PIONEER/rekordbox/export.pdb");
+    let mut reader = Cursor::new(data.as_slice());
+    let mut db = Database::open_non_persistent(&mut reader, DatabaseType::Plain).unwrap();
+
+    let rows: Vec<_> = db
+        .iter_rows::<Unknown18Row>()
+        .unwrap()
+        .map(|row| Ok(*row))
+        .collect()
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![
+            Unknown18Row::new(1, 6, 0x0001, 0),
+            Unknown18Row::new(21, 7, 0x0001, 0),
+            Unknown18Row::new(14, 8, 0x0001, 0),
+            Unknown18Row::new(8, 9, 0x0001, 0),
+            Unknown18Row::new(9, 10, 0x0001, 0),
+            Unknown18Row::new(10, 11, 0x0001, 0),
+            Unknown18Row::new(15, 13, 0x0001, 0),
+            Unknown18Row::new(13, 15, 0x0001, 0),
+            Unknown18Row::new(23, 16, 0x0001, 0),
+            Unknown18Row::new(22, 17, 0x0001, 0),
+            Unknown18Row::new(25, 0, 0x0100, 0),
+            Unknown18Row::new(26, 1, 0x0200, 0),
+            Unknown18Row::new(2, 2, 0x0300, 0),
+            Unknown18Row::new(3, 3, 0x0400, 0),
+            Unknown18Row::new(5, 4, 0x0500, 0),
+            Unknown18Row::new(6, 5, 0x0600, 0),
+            Unknown18Row::new(11, 12, 0x0700, 0),
+        ]
+    );
+}
+
+#[test]
+fn parses_export_ext_table_7_row() {
+    let data =
+        include_bytes!("../data/complete_export/demo_tracks/PIONEER/rekordbox/exportExt.pdb");
+    let mut reader = Cursor::new(data.as_slice());
+    let mut db = Database::open_non_persistent(&mut reader, DatabaseType::Ext).unwrap();
+
+    let mut rows = db.iter_rows::<Unknown7Row>().unwrap();
+    let row = *rows.next().unwrap().unwrap();
+    assert!(rows.next().unwrap().is_none());
+
+    assert_eq!(row.reserved0, 0x0700);
+    assert_eq!(row.data_page, 0);
+    assert_eq!(row.table_id, 0);
+    assert_eq!(row.empty_candidate_page, 0);
+    assert_eq!(row.state, 0);
+    assert_eq!(row.reserved1, 0);
+    assert_eq!(row.flags0.into_bytes(), [0x81, 0xfa, 0xe7, 0x05]);
+    assert_eq!(row.flags1.into_bytes(), [0x03, 0x22, 0x23, 0x24]);
+    assert_eq!(row.version, 0x03032625);
+    assert_eq!(row.reserved2, 0x00030303);
+    assert_eq!(row.flags2.into_bytes(), [0; 4]);
+    assert_eq!(
+        [row.reserved3, row.reserved4, row.reserved5, row.reserved6],
+        [0; 4]
+    );
+}
+
+#[test]
+fn serializes_typed_opaque_rows() {
+    let row18 = Unknown18Row::new(21, 7, 1, 0);
+    let mut bytes = Cursor::new(Vec::new());
+    row18.write_options(&mut bytes, Endian::Little, ()).unwrap();
+    assert_eq!(bytes.get_ref(), &[21, 0, 7, 0, 1, 0, 0, 0]);
+    let parsed18 =
+        Unknown18Row::read_options(&mut Cursor::new(bytes.into_inner()), Endian::Little, ())
+            .unwrap();
+    assert_eq!(parsed18, row18);
+
+    let row7 = Unknown7Row::new(
+        0,
+        16,
+        7,
+        19,
+        1,
+        0,
+        Unknown7Flags0::canonical(),
+        Unknown7Flags1::canonical(),
+        1,
+        0,
+        Unknown7Flags2::canonical(),
+        0,
+        0,
+        0,
+        0,
+    );
+    let mut bytes = Cursor::new(Vec::new());
+    row7.write_options(&mut bytes, Endian::Little, ()).unwrap();
+    assert_eq!(bytes.get_ref().len(), 60);
+    let parsed7 =
+        Unknown7Row::read_options(&mut Cursor::new(bytes.into_inner()), Endian::Little, ())
+            .unwrap();
+    assert_eq!(parsed7, row7);
+
+    for (row, page_type) in [
+        (Row::Unknown18(row18), PageType::Unknown(18)),
+        (Row::Unknown7(row7), PageType::Unknown(7)),
+    ] {
+        let mut bytes = Cursor::new(Vec::new());
+        row.write_options(&mut bytes, Endian::Little, ()).unwrap();
+        let parsed = Row::read_options(
+            &mut Cursor::new(bytes.into_inner()),
+            Endian::Little,
+            (page_type,),
+        )
+        .unwrap();
+        assert_eq!(parsed, row);
+    }
+}


### PR DESCRIPTION
These two tables appear to be essential to creating a functioning PDB file that will be read by Pioneer equipment, so we need a way to construct them in code even though we don't know how they work exactly.

## Summary

- add typed `Unknown18Row` support for the fixed 8-byte rows in plain PDB table 18
- add typed `Unknown7Row` support for the fixed 60-byte rows in `exportExt.pdb` table 7
- model table-7 flag words as preserving bitfields and integrate both row types with `Row`, `RowVariant`, and page-heap sizing
- cover parsing against the existing demo export fixtures and direct row/enum serialization round trips

This is intentionally limited to the two previously opaque, fixed-layout tables; other unknown page types remain opaque.

## Checks

- `cargo fmt -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --no-default-features --all-targets`
- `cargo test --all-targets --all-features`